### PR TITLE
[Feat] Spring Security 설정 및 로그인, 로그아웃 구현

### DIFF
--- a/src/main/java/sandbox/semo/common/config/SecurityConfig.java
+++ b/src/main/java/sandbox/semo/common/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package sandbox.semo.common.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import sandbox.semo.security.authentication.MemberAuthProvider;
+
+@Log4j2
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final MemberAuthProvider memberAuthProvider;
+    private final AuthenticationSuccessHandler successHandler;
+    private final AuthenticationFailureHandler failureHandler;
+    private final AuthenticationEntryPoint entryPoint;
+
+    @Autowired
+    public void configure(AuthenticationManagerBuilder auth) {
+        auth.authenticationProvider(memberAuthProvider);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/",
+                                "/api/v1/**"
+                        ).permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(form -> form
+                        .loginProcessingUrl("/api/v1/login")
+                        .successHandler(successHandler)
+                        .failureHandler(failureHandler)
+                        .permitAll())
+                .logout(exit -> exit
+                        .logoutUrl("/api/v1/logout")
+                        .deleteCookies("JSESSIONID")
+                        .invalidateHttpSession(true)
+                        .logoutSuccessHandler((
+                                (request, response, authentication)
+                                        -> SecurityContextHolder.clearContext()
+                        )))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(entryPoint));
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/sandbox/semo/common/entity/BaseTime.java
+++ b/src/main/java/sandbox/semo/common/entity/BaseTime.java
@@ -1,0 +1,32 @@
+package sandbox.semo.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    @Column(name = "CREATED_AT", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "UPDATED_AT", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "DELETED_AT")
+    private LocalDateTime deletedAt;
+
+    public void markAsDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/sandbox/semo/company/entity/Company.java
+++ b/src/main/java/sandbox/semo/company/entity/Company.java
@@ -1,0 +1,35 @@
+package sandbox.semo.company.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "COMPANIES")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "COMPANY_SEQ_GEN")
+    @SequenceGenerator(name = "COMPANY_SEQ_GEN", sequenceName = "COMPANY_SEQ", allocationSize = 1)
+    @Column(name = "COMPANY_ID", nullable = false)
+    private Long id;
+
+    @Column(name = "COMPANY_NAME", nullable = false, length = 50)
+    private String companyName;
+
+    @Builder
+    public Company(String companyName) {
+        this.companyName = companyName;
+    }
+
+}

--- a/src/main/java/sandbox/semo/company/repository/CompanyRepository.java
+++ b/src/main/java/sandbox/semo/company/repository/CompanyRepository.java
@@ -1,0 +1,8 @@
+package sandbox.semo.company.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sandbox.semo.company.entity.Company;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+}

--- a/src/main/java/sandbox/semo/member/controller/MemberController.java
+++ b/src/main/java/sandbox/semo/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package sandbox.semo.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sandbox.semo.member.dto.request.MemberRegister;
+import sandbox.semo.member.service.MemberService;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<?> register(@RequestBody MemberRegister memberRegister) {
+        memberService.register(memberRegister);
+        return ResponseEntity.ok()
+                .body("성공적으로 계정 생성이 완료 되었습니다.");
+    }
+
+}

--- a/src/main/java/sandbox/semo/member/dto/request/MemberRegister.java
+++ b/src/main/java/sandbox/semo/member/dto/request/MemberRegister.java
@@ -1,0 +1,24 @@
+package sandbox.semo.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class MemberRegister {
+
+    @NotNull
+    private Long companyId;
+
+    @NotNull
+    private String loginId;
+
+    @NotNull
+    private String ownerName;
+
+    @NotNull
+    private String password;
+
+    @NotNull
+    private String role;
+
+}

--- a/src/main/java/sandbox/semo/member/entity/Member.java
+++ b/src/main/java/sandbox/semo/member/entity/Member.java
@@ -1,0 +1,60 @@
+package sandbox.semo.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sandbox.semo.common.entity.BaseTime;
+import sandbox.semo.company.entity.Company;
+
+@Entity
+@Getter
+@Table(name = "MEMBERS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_SEQ_GEN")
+    @SequenceGenerator(name = "MEMBER_SEQ_GEN", sequenceName = "MEMBER_SEQ", allocationSize = 1)
+    @Column(name = "MEMBER_ID", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "COMPANY_ID", nullable = false)
+    private Company company;
+
+    @Column(name = "OWNER_NAME", nullable = false, length = 30)
+    private String ownerName;
+
+    @Column(name = "LOGIN_ID", nullable = false, unique = true, length = 50)
+    private String loginId;
+
+    @Column(name = "PASSWORD", nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ROLE", nullable = false, length = 20)
+    private Role role;
+
+    @Builder
+    public Member(Company company, String ownerName, String loginId, String password, Role role) {
+        this.company = company;
+        this.ownerName = ownerName;
+        this.loginId = loginId;
+        this.password = password;
+        this.role = role;
+    }
+
+}

--- a/src/main/java/sandbox/semo/member/entity/Role.java
+++ b/src/main/java/sandbox/semo/member/entity/Role.java
@@ -1,0 +1,5 @@
+package sandbox.semo.member.entity;
+
+public enum Role {
+    SUPER, ADMIN, USER
+}

--- a/src/main/java/sandbox/semo/member/repository/MemberRepository.java
+++ b/src/main/java/sandbox/semo/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package sandbox.semo.member.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import sandbox.semo.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByLoginId(String loginId);
+    Optional<Member> findByLoginIdAndDeletedAtIsNull(String loginId);
+
+}

--- a/src/main/java/sandbox/semo/member/service/MemberService.java
+++ b/src/main/java/sandbox/semo/member/service/MemberService.java
@@ -1,0 +1,9 @@
+package sandbox.semo.member.service;
+
+import sandbox.semo.member.dto.request.MemberRegister;
+
+public interface MemberService {
+
+    void register(MemberRegister request);
+
+}

--- a/src/main/java/sandbox/semo/member/service/MemberServiceImpl.java
+++ b/src/main/java/sandbox/semo/member/service/MemberServiceImpl.java
@@ -1,0 +1,39 @@
+package sandbox.semo.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import sandbox.semo.member.dto.request.MemberRegister;
+import sandbox.semo.company.entity.Company;
+import sandbox.semo.member.entity.Member;
+import sandbox.semo.member.entity.Role;
+import sandbox.semo.company.repository.CompanyRepository;
+import sandbox.semo.member.repository.MemberRepository;
+
+// TODO: Security 설정 확인 용도로 가볍게 구현 했음. Member API 개발시 추가 코드 필요.
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final CompanyRepository companyRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void register(MemberRegister request) {
+        Member member = Member.builder()
+                .company(getCompanyById(request.getCompanyId()))
+                .ownerName(request.getOwnerName())
+                .loginId(request.getLoginId())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(Role.valueOf(request.getRole()))
+                .build();
+        memberRepository.save(member);
+    }
+
+    private Company getCompanyById(Long companyId) {
+        return companyRepository.findById(companyId)
+                .orElseThrow(() -> new RuntimeException("Company not found"));
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/authentication/MemberAuthFailureHandler.java
+++ b/src/main/java/sandbox/semo/security/authentication/MemberAuthFailureHandler.java
@@ -1,0 +1,36 @@
+package sandbox.semo.security.authentication;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import sandbox.semo.security.exception.ErrorCode;
+import sandbox.semo.security.util.JsonResponseHelper;
+
+@Log4j2
+@Component
+public class MemberAuthFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException, ServletException {
+        log.error(">>> [ ❌ 인증 실패: {} ]", exception.getMessage());
+        ErrorCode errorCode = getErrorMessage(exception);
+        JsonResponseHelper.sendJsonErrorResponse(response, errorCode);
+    }
+
+    private ErrorCode getErrorMessage(AuthenticationException exception) {
+        if (exception instanceof UsernameNotFoundException
+                || exception instanceof BadCredentialsException) {
+            return ErrorCode.INVALID_CREDENTIALS;
+        }
+        return ErrorCode.UNAUTHORIZED_USER;
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/authentication/MemberAuthProvider.java
+++ b/src/main/java/sandbox/semo/security/authentication/MemberAuthProvider.java
@@ -1,0 +1,49 @@
+package sandbox.semo.security.authentication;
+
+import static sandbox.semo.security.exception.ErrorCode.INVALID_CREDENTIALS;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class MemberAuthProvider implements AuthenticationProvider {
+
+    private final MemberPrincipalDetailService memberPrincipalDetailService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+            throws AuthenticationException {
+        String loginId = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        log.info(">>> [ 🚀 로그인 시도 - 아이디: {} ]", loginId);
+        MemberPrincipalDetails memberPrincipalDetails =
+                (MemberPrincipalDetails) memberPrincipalDetailService.loadUserByUsername(loginId);
+
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        if (!passwordEncoder.matches(password, memberPrincipalDetails.getPassword())) {
+            throw new BadCredentialsException(INVALID_CREDENTIALS.getMessage());
+        }
+
+        log.info(">>> [ ✅ 사용자 인증이 완료 되었습니다. ]");
+        return new UsernamePasswordAuthenticationToken(
+                memberPrincipalDetails, null, memberPrincipalDetails.getAuthorities()
+        );
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/authentication/MemberAuthSuccessHandler.java
+++ b/src/main/java/sandbox/semo/security/authentication/MemberAuthSuccessHandler.java
@@ -1,0 +1,37 @@
+package sandbox.semo.security.authentication;
+
+import static sandbox.semo.security.exception.ErrorCode.UNAUTHORIZED_USER;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import sandbox.semo.security.util.JsonResponseHelper;
+
+@Component
+public class MemberAuthSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException, ServletException {
+        String role = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElseThrow(() -> new BadCredentialsException(UNAUTHORIZED_USER.getMessage()));
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("code", 200);
+        responseBody.put("message", "사용자 인증이 완료 되어 로그인 되었습니다.");
+        responseBody.put("data", Map.of("ROLE", role));
+
+        JsonResponseHelper.sendJsonSuccessResponse(response, responseBody);
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/authentication/MemberPrincipalDetailService.java
+++ b/src/main/java/sandbox/semo/security/authentication/MemberPrincipalDetailService.java
@@ -1,0 +1,26 @@
+package sandbox.semo.security.authentication;
+
+import static sandbox.semo.security.exception.ErrorCode.INVALID_CREDENTIALS;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import sandbox.semo.member.entity.Member;
+import sandbox.semo.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberPrincipalDetailService implements UserDetailsService {
+
+    private final MemberRepository repository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Member member = repository.findByLoginIdAndDeletedAtIsNull(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException(INVALID_CREDENTIALS.getMessage()));
+        return new MemberPrincipalDetails(member);
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/authentication/MemberPrincipalDetails.java
+++ b/src/main/java/sandbox/semo/security/authentication/MemberPrincipalDetails.java
@@ -1,0 +1,33 @@
+package sandbox.semo.security.authentication;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import sandbox.semo.member.entity.Member;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberPrincipalDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(member.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getLoginId();
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/exception/ErrorCode.java
+++ b/src/main/java/sandbox/semo/security/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package sandbox.semo.security.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    INVALID_CREDENTIALS("아이디 또는 비밀번호가 일치하지 않습니다.", BAD_REQUEST),
+    UNAUTHORIZED_USER("인증 되지 않은 사용자 입니다. 다시 한번 확인해 주세요.", UNAUTHORIZED);
+
+    private final String message;
+    private final HttpStatus status;
+
+}

--- a/src/main/java/sandbox/semo/security/exception/MemberAuthExceptionEntryPoint.java
+++ b/src/main/java/sandbox/semo/security/exception/MemberAuthExceptionEntryPoint.java
@@ -1,0 +1,25 @@
+package sandbox.semo.security.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import sandbox.semo.security.util.JsonResponseHelper;
+
+@Log4j2
+@Component
+public class MemberAuthExceptionEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+        log.error(">>> [ ❌ 인증 실패: {} ]", authException.getMessage());
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED_USER;
+        JsonResponseHelper.sendJsonErrorResponse(response, errorCode);
+    }
+
+}

--- a/src/main/java/sandbox/semo/security/util/JsonResponseHelper.java
+++ b/src/main/java/sandbox/semo/security/util/JsonResponseHelper.java
@@ -1,0 +1,37 @@
+package sandbox.semo.security.util;
+
+import static org.springframework.http.HttpStatus.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import sandbox.semo.security.exception.ErrorCode;
+
+public class JsonResponseHelper {
+
+    public static void sendJsonSuccessResponse(
+            HttpServletResponse response, Map<String, Object> responseBody
+    ) throws IOException {
+        response.setStatus(OK.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ObjectMapper mapper = new ObjectMapper();
+        response.getWriter().write(mapper.writeValueAsString(responseBody));
+    }
+
+    public static void sendJsonErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+            throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("code", errorCode.getStatus().value());
+        responseBody.put("message", errorCode.getMessage());
+
+        ObjectMapper mapper = new ObjectMapper();
+        response.getWriter().write(mapper.writeValueAsString(responseBody));
+    }
+
+}


### PR DESCRIPTION
## #️⃣ Relationship Issues
- #1 

<br>

## 💡 Key Changes
### 1️⃣ Spring Security 의존성 추가
- SEMO 서비스는 3가지(SUPER, ADMIN, USER)의 여러 권한을 가지고 있기 때문에 권한 관리 및 보안에 장점을 가지고 있는 Spring Securtiy 의존성을 추가하여 기본 설정을 마쳤습니다.

### 2️⃣ SecurityConfig 설정 범위
- 설정 범위는 Member Login, Logout에 해당하며, 로그인 성공시 응답, 실패 응답, 예외 응답을 핸들링할 수 있도록 구현하였습니다.

## ✅ Test - PostMan Tool 사용
### 로그인 성공 
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/07cd0dfa-64df-4216-b81d-9165bca74493">

### 로그인 실패 - 아이디 또는 비밀번호 불일치
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/82a6276a-bd09-4a35-8c41-f0c7535bb557">

<br>

## ➕ ETC 
- `Member`, `Company` Entity의 일부 로직이 시큐리티 설정에 필요하여 불가피하게 간단하게 작성되었습니다.
- `Member`, `Company` 도메인 API 개발시에 추가적인 개선과 추가 로직이 필요합니다.