### PR TITLE
[Feat] 장비(Device) 등록 및 데이터베이스 상태 체크 API 구현

### DIFF
--- a/semo-api/src/main/java/sandbox/semo/application/common/config/SecurityConfig.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package sandbox.semo.application.common.config;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -28,6 +30,12 @@ public class SecurityConfig {
     private final AuthenticationSuccessHandler successHandler;
     private final AuthenticationFailureHandler failureHandler;
     private final AuthenticationEntryPoint entryPoint;
+
+    @Value("${encryption.aes.secret}")
+    private String symmetricKey;
+
+    @Value("${encryption.aes.salt}")
+    private String saltKey;
 
     @Autowired
     public void configure(AuthenticationManagerBuilder auth) {
@@ -66,6 +74,11 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AesBytesEncryptor aesBytesEncryptor() {
+        return new AesBytesEncryptor(symmetricKey, saltKey);
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/common/exception/CommonErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/exception/CommonErrorCode.java
@@ -1,4 +1,4 @@
-package sandbox.semo.common.exception;
+package sandbox.semo.application.common.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/semo-api/src/main/java/sandbox/semo/application/common/exception/ErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package sandbox.semo.common.exception;
+package sandbox.semo.application.common.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/semo-api/src/main/java/sandbox/semo/application/common/util/AES256.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/util/AES256.java
@@ -1,0 +1,25 @@
+package sandbox.semo.application.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+
+public class AES256 {
+
+    private static AesBytesEncryptor getEncryptor() {
+        return ApplicationContextUtil.getBean(AesBytesEncryptor.class);
+    }
+
+    public static String encrypt(String plainText) {
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+        byte[] encryptedBytes = getEncryptor().encrypt(plainBytes);
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    private static String decrypt(String encryptedText) {
+        byte[] encryptedBytes = Base64.getDecoder().decode(encryptedText);
+        byte[] decryptedBytes = getEncryptor().decrypt(encryptedBytes);
+        return new String(decryptedBytes, StandardCharsets.UTF_8);
+    }
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/common/util/ApplicationContextUtil.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/util/ApplicationContextUtil.java
@@ -1,0 +1,21 @@
+package sandbox.semo.application.common.util;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextUtil implements ApplicationContextAware {
+
+    private static ApplicationContext context;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        context = applicationContext;
+    }
+
+    public static <T> T getBean(Class<T> beanClass) {
+        return context.getBean(beanClass);
+    }
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
@@ -2,15 +2,20 @@ package sandbox.semo.application.device.controller;
 
 import static org.springframework.http.HttpStatus.OK;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.device.service.DeviceService;
-import sandbox.semo.domain.device.dto.request.HealthCheck;
+import sandbox.semo.application.security.authentication.MemberPrincipalDetails;
+import sandbox.semo.domain.device.dto.request.DeviceRegister;
+import sandbox.semo.domain.device.dto.request.DataBaseInfo;
 
 @Log4j2
 @RestController
@@ -21,9 +26,19 @@ public class DeviceController {
     private final DeviceService deviceService;
 
     @PostMapping("/hc")
-    public ApiResponse<Boolean> testConnect(@RequestBody HealthCheck request) {
-        deviceService.healthCheck(request);
-        return ApiResponse.successResponse(OK, "DEVICE 상태가 양호 합니다.");
+    public ApiResponse<Boolean> testConnect(@Valid @RequestBody DataBaseInfo request) {
+        boolean status = deviceService.healthCheck(request);
+        return ApiResponse.successResponse(OK, "DEVICE 상태가 양호 합니다.", status);
+    }
+
+    @PreAuthorize("hasAnyRole('SUPER', 'ADMIN')")
+    @PostMapping
+    public ApiResponse<Void> register(
+            @RequestBody DeviceRegister request,
+            @AuthenticationPrincipal MemberPrincipalDetails memberDetails
+    ) {
+        deviceService.register(memberDetails.getMember().getCompany(), request);
+        return ApiResponse.successResponse(OK, "성공적으로 DEVICE가 등록되었습니다.");
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.device.service.DeviceService;
-import sandbox.semo.domain.device.dto.request.DeviceRegister;
+import sandbox.semo.domain.device.dto.request.HealthCheck;
 
 @Log4j2
 @RestController
@@ -21,8 +21,8 @@ public class DeviceController {
     private final DeviceService deviceService;
 
     @PostMapping("/hc")
-    public ApiResponse<Boolean> testConnect(@RequestBody DeviceRegister deviceRegister) {
-        deviceService.healthCheck(deviceRegister);
+    public ApiResponse<Boolean> testConnect(@RequestBody HealthCheck request) {
+        deviceService.healthCheck(request);
         return ApiResponse.successResponse(OK, "DEVICE 상태가 양호 합니다.");
     }
 

--- a/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
@@ -1,0 +1,29 @@
+package sandbox.semo.application.device.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sandbox.semo.application.common.response.ApiResponse;
+import sandbox.semo.application.device.service.DeviceService;
+import sandbox.semo.domain.device.dto.request.DeviceRegister;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/device")
+public class DeviceController {
+
+    private final DeviceService deviceService;
+
+    @PostMapping("/hc")
+    public ApiResponse<Boolean> testConnect(@RequestBody DeviceRegister deviceRegister) {
+        deviceService.healthCheck(deviceRegister);
+        return ApiResponse.successResponse(OK, "DEVICE 상태가 양호 합니다.");
+    }
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/device/exception/DeviceBusinessException.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/exception/DeviceBusinessException.java
@@ -1,0 +1,14 @@
+package sandbox.semo.application.device.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DeviceBusinessException extends RuntimeException {
+
+    private final DeviceErrorCode deviceErrorCode;
+
+    public DeviceBusinessException(DeviceErrorCode deviceErrorCode) {
+        super(deviceErrorCode.getMessage());
+        this.deviceErrorCode = deviceErrorCode;
+    }
+}

--- a/semo-api/src/main/java/sandbox/semo/application/device/exception/DeviceErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/exception/DeviceErrorCode.java
@@ -1,0 +1,21 @@
+package sandbox.semo.application.device.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import sandbox.semo.application.common.exception.ErrorCode;
+
+@RequiredArgsConstructor
+@Getter
+public enum DeviceErrorCode implements ErrorCode {
+
+    DATABASE_CONNECTION_FAILURE(INTERNAL_SERVER_ERROR, "데이터베이스 연결에 실패했습니다."),
+    ACCESS_DENIED(FORBIDDEN, "테이블에 접근할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
@@ -1,9 +1,13 @@
 package sandbox.semo.application.device.service;
 
-import sandbox.semo.domain.device.dto.request.HealthCheck;
+import sandbox.semo.domain.company.entity.Company;
+import sandbox.semo.domain.device.dto.request.DeviceRegister;
+import sandbox.semo.domain.device.dto.request.DataBaseInfo;
 
 public interface DeviceService {
 
-    void healthCheck(HealthCheck request);
+    boolean healthCheck(DataBaseInfo request);
+
+    void register(Company company, DeviceRegister request);
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
@@ -1,0 +1,9 @@
+package sandbox.semo.application.device.service;
+
+import sandbox.semo.domain.device.dto.request.DeviceRegister;
+
+public interface DeviceService {
+
+    void healthCheck(DeviceRegister request);
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
@@ -1,9 +1,9 @@
 package sandbox.semo.application.device.service;
 
-import sandbox.semo.domain.device.dto.request.DeviceRegister;
+import sandbox.semo.domain.device.dto.request.HealthCheck;
 
 public interface DeviceService {
 
-    void healthCheck(DeviceRegister request);
+    void healthCheck(HealthCheck request);
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
@@ -1,0 +1,61 @@
+package sandbox.semo.application.device.service;
+
+import static sandbox.semo.application.device.exception.DeviceErrorCode.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import sandbox.semo.application.device.exception.DeviceBusinessException;
+import sandbox.semo.domain.device.dto.request.DeviceRegister;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class DeviceServiceImpl implements DeviceService {
+
+    @Override
+    public void healthCheck(DeviceRegister request) {
+        try (Connection conn = getDBConnection(request)) {
+            validateDBConnection(conn);
+            checkVSessionAccess(conn);
+        } catch (SQLException e) {
+            throw new DeviceBusinessException(DATABASE_CONNECTION_FAILURE);
+        }
+    }
+
+    private void checkVSessionAccess(Connection conn) throws SQLException {
+        String checkQuery = "SELECT 1 FROM v$session WHERE ROWNUM = 1";
+
+        try (
+                var stmt = conn.createStatement();
+                var rs = stmt.executeQuery(checkQuery)
+        ) {
+            if (!rs.next()) {
+                log.warn(">>> [ ❌ v$session 테이블에 접근이 불가능 합니다. ]");
+                throw new DeviceBusinessException(ACCESS_DENIED);
+            }
+        }
+        log.info(">>> [ ✅ v$session 테이블 접근 가능 ]");
+    }
+
+    private void validateDBConnection(Connection conn) throws SQLException {
+        if (!conn.isValid(2)) {
+            log.warn(">>> [ ❌ 데이터베이스 연결 실패: 연결 시도 시간 초과 ]");
+            throw new DeviceBusinessException(DATABASE_CONNECTION_FAILURE);
+        }
+        log.info(">>> [ ✅ 데이터베이스 연결 체크 성공 ]");
+    }
+
+    private Connection getDBConnection(DeviceRegister request) throws SQLException {
+        String url = getConnectionUrl(request.getIp(), request.getPort(), request.getSid());
+        return DriverManager.getConnection(url, request.getUsername(), request.getPassword());
+    }
+
+    private String getConnectionUrl(String ip, Long port, String sId) {
+        return "jdbc:oracle:thin:@" + ip + ":" + port + ":" + sId;
+    }
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import sandbox.semo.application.device.exception.DeviceBusinessException;
-import sandbox.semo.domain.device.dto.request.DeviceRegister;
+import sandbox.semo.domain.device.dto.request.HealthCheck;
 
 @Service
 @Log4j2
@@ -17,7 +17,7 @@ import sandbox.semo.domain.device.dto.request.DeviceRegister;
 public class DeviceServiceImpl implements DeviceService {
 
     @Override
-    public void healthCheck(DeviceRegister request) {
+    public void healthCheck(HealthCheck request) {
         try (Connection conn = getDBConnection(request)) {
             validateDBConnection(conn);
             checkVSessionAccess(conn);
@@ -49,7 +49,7 @@ public class DeviceServiceImpl implements DeviceService {
         log.info(">>> [ ✅ 데이터베이스 연결 체크 성공 ]");
     }
 
-    private Connection getDBConnection(DeviceRegister request) throws SQLException {
+    private Connection getDBConnection(HealthCheck request) throws SQLException {
         String url = getConnectionUrl(request.getIp(), request.getPort(), request.getSid());
         return DriverManager.getConnection(url, request.getUsername(), request.getPassword());
     }

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
@@ -26,6 +26,9 @@ public class DeviceServiceImpl implements DeviceService {
     @Override
     public void register(Company company, DeviceRegister request) {
         DataBaseInfo dataBaseInfo = request.getDataBaseInfo();
+        if (!healthCheck(dataBaseInfo)) {
+            throw new DeviceBusinessException(DATABASE_CONNECTION_FAILURE);
+        }
         deviceRepository.save(Device.builder()
                 .company(company)
                 .deviceAlias(request.getDeviceAlias())

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import sandbox.semo.application.common.util.AES256;
 import sandbox.semo.application.device.exception.DeviceBusinessException;
 import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.device.dto.request.DeviceRegister;
@@ -33,7 +34,7 @@ public class DeviceServiceImpl implements DeviceService {
                 .port(dataBaseInfo.getPort())
                 .sid(dataBaseInfo.getSid())
                 .username(dataBaseInfo.getUsername())
-                .password(dataBaseInfo.getPassword())
+                .password(AES256.encrypt(dataBaseInfo.getPassword()))
                 .status(healthCheck(dataBaseInfo))
                 .build());
         log.info(">>> [ ✅ 데이터베이스 장비가 성공적으로 등록되었습니다. ]");

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sandbox.semo.application.common.util.AES256;
 import sandbox.semo.application.device.exception.DeviceBusinessException;
 import sandbox.semo.domain.company.entity.Company;
@@ -18,11 +19,13 @@ import sandbox.semo.domain.device.repository.DeviceRepository;
 
 @Service
 @Log4j2
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DeviceServiceImpl implements DeviceService {
 
     private final DeviceRepository deviceRepository;
 
+    @Transactional
     @Override
     public void register(Company company, DeviceRegister request) {
         DataBaseInfo dataBaseInfo = request.getDataBaseInfo();

--- a/semo-api/src/main/java/sandbox/semo/application/member/exception/MemberBusinessException.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/exception/MemberBusinessException.java
@@ -1,4 +1,4 @@
-package sandbox.semo.member.exception;
+package sandbox.semo.application.member.exception;
 
 import lombok.Getter;
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/exception/MemberErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/exception/MemberErrorCode.java
@@ -1,21 +1,19 @@
-package sandbox.semo.member.exception;
+package sandbox.semo.application.member.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import sandbox.semo.common.exception.ErrorCode;
+import sandbox.semo.application.common.exception.ErrorCode;
 
 @RequiredArgsConstructor
 @Getter
 public enum MemberErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-    UNAUTHORIZED_TO_MEMBER(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
-    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "입력하신 비밀번호를 다시 확인해 주세요.");
+    MEMBER_NOT_FOUND(NOT_FOUND, "존재하지 않는 사용자입니다."),
+    UNAUTHORIZED_TO_MEMBER(FORBIDDEN, "권한이 없는 사용자입니다."),
+    WRONG_PASSWORD(BAD_REQUEST, "입력하신 비밀번호를 다시 확인해 주세요.");
 
     private final HttpStatus httpStatus;
 

--- a/semo-api/src/main/java/sandbox/semo/application/security/exception/AuthErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/exception/AuthErrorCode.java
@@ -1,16 +1,18 @@
 package sandbox.semo.application.security.exception;
 
+import static org.springframework.http.HttpStatus.*;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import sandbox.semo.common.exception.ErrorCode;
+import sandbox.semo.application.common.exception.ErrorCode;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST,  "아이디 또는 비밀번호가 일치하지 않습니다."),
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "인증 되지 않은 사용자 입니다. 다시 한번 확인해 주세요.");
+    INVALID_CREDENTIALS(BAD_REQUEST,  "아이디 또는 비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED_USER(UNAUTHORIZED, "인증 되지 않은 사용자 입니다. 다시 한번 확인해 주세요.");
 
     private final HttpStatus httpStatus;
 

--- a/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/DataBaseInfo.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/DataBaseInfo.java
@@ -1,18 +1,20 @@
 package sandbox.semo.domain.device.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import sandbox.semo.domain.device.entity.DatabaseType;
 
 @Data
-public class HealthCheck {
+public class DataBaseInfo {
 
-    @NotBlank
-    private String type;
+    @NotNull
+    private DatabaseType type;
 
     @NotBlank
     private String ip;
 
-    @NotBlank
+    @NotNull
     private Long port;
 
     @NotBlank

--- a/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/DeviceRegister.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/DeviceRegister.java
@@ -1,0 +1,27 @@
+package sandbox.semo.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class DeviceRegister {
+
+    @NotBlank
+    private String type;
+
+    @NotBlank
+    private String ip;
+
+    @NotBlank
+    private Long port;
+
+    @NotBlank
+    private String sid;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/DeviceRegister.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/DeviceRegister.java
@@ -1,0 +1,16 @@
+package sandbox.semo.domain.device.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class DeviceRegister {
+
+    @NotBlank
+    private String deviceAlias;
+
+    @Valid
+    private DataBaseInfo dataBaseInfo;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/HealthCheck.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/dto/request/HealthCheck.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
-public class DeviceRegister {
+public class HealthCheck {
 
     @NotBlank
     private String type;

--- a/semo-core/src/main/java/sandbox/semo/domain/device/entity/DatabaseType.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/entity/DatabaseType.java
@@ -1,0 +1,5 @@
+package sandbox.semo.domain.device.entity;
+
+public enum DatabaseType {
+    ORACLE, POSTGRESQL, MYSQL, MARIADB, SQLSERVER;
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/device/entity/Device.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/entity/Device.java
@@ -1,0 +1,74 @@
+package sandbox.semo.domain.device.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sandbox.semo.domain.company.entity.Company;
+import sandbox.semo.domain.common.entity.BaseTime;
+
+@Entity
+@Getter
+@Table(name = "DEVICES")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Device extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "DEVICE_SEQ_GEN")
+    @SequenceGenerator(name = "DEVICE_SEQ_GEN", sequenceName = "DEVICE_SEQ", allocationSize = 1)
+    @Column(name = "DEVICE_ID", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "COMPANY_ID", nullable = false)
+    private Company company;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "TYPE", nullable = false, length = 30)
+    private DatabaseType type;
+
+    @Column(name = "IP", nullable = false, length = 100)
+    private String ip;
+
+    @Column(name = "PORT", nullable = false)
+    private Long port;
+
+    @Column(name = "SID", nullable = false, length = 50)
+    private String sId;
+
+    @Column(name = "USERNAME", nullable = false, length = 50)
+    private String username;
+
+    @Column(name = "PASSWORD", nullable = false)
+    private String password;
+
+    @Column(name = "STATUS", nullable = false)
+    private Boolean status;
+
+    @Builder
+    public Device(
+            Company company, DatabaseType type, String ip, Long port, String sId, String username,
+            String password, Boolean status) {
+        this.company = company;
+        this.type = type;
+        this.ip = ip;
+        this.port = port;
+        this.sId = sId;
+        this.username = username;
+        this.password = password;
+        this.status = status;
+    }
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/device/entity/Device.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/entity/Device.java
@@ -35,6 +35,9 @@ public class Device extends BaseTime {
     @JoinColumn(name = "COMPANY_ID", nullable = false)
     private Company company;
 
+    @Column(name = "DEVICE_ALIAS", nullable = false, length = 100)
+    private String deviceAlias;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "TYPE", nullable = false, length = 30)
     private DatabaseType type;
@@ -46,7 +49,7 @@ public class Device extends BaseTime {
     private Long port;
 
     @Column(name = "SID", nullable = false, length = 50)
-    private String sId;
+    private String sid;
 
     @Column(name = "USERNAME", nullable = false, length = 50)
     private String username;
@@ -59,13 +62,14 @@ public class Device extends BaseTime {
 
     @Builder
     public Device(
-            Company company, DatabaseType type, String ip, Long port, String sId, String username,
+            Company company, String deviceAlias, DatabaseType type, String ip, Long port, String sid, String username,
             String password, Boolean status) {
         this.company = company;
+        this.deviceAlias = deviceAlias;
         this.type = type;
         this.ip = ip;
         this.port = port;
-        this.sId = sId;
+        this.sid = sid;
         this.username = username;
         this.password = password;
         this.status = status;

--- a/semo-core/src/main/java/sandbox/semo/domain/device/repository/DeviceRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/repository/DeviceRepository.java
@@ -1,0 +1,8 @@
+package sandbox.semo.domain.device.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sandbox.semo.domain.device.entity.Device;
+
+public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+}


### PR DESCRIPTION
## #️⃣ Relationship Issues
- #6  

<br>

## 💡 Key Changes
### 1️⃣ Device Test Connection API
- 장비 등록시 사용자가 데이터베이스의 상태를 확인할 수 있도록 데이터베이스 상태를 확인하는 API 추가
- API url: `[POST]  /api/v1/device/hc`
- 장비 상태 확인 Query: `SELECT 1 FROM v$session WHERE ROWNUM = 1`

### 2️⃣ Device Register API
- `SUPER`, `ADMIN` 권한을 가진 계정이 모니터링 대상 장비(Device)를 등록할 수 있는 API 추가
- API url: `[POST] /api/v1/device`

### 3️⃣ AES256 설정
- 장비 등록시 Database password AES256 대칭키 암호화 적용
- Util 성 클래스로 전역 메소드를 사용할 수 있도록 메서드 개발
- ApplicationContextUtil 클래스를 추가해서 등록된 Bean을 가져와서 전역(static) 메서드로 사용할 수 있도록 개발

## ✅ Test - PostMan Tool 사용
> 테스트는 localhost의 Oracle Database의 IP, PORT, SID, USERNAME, PASSWORD 를 적용했습니다.
### 🚀 Test Connection
<img width="700" alt="image" src="https://github.com/user-attachments/assets/23255e65-c573-4e22-9c4b-f851dd6434c9">

### 🚀 Device Register
<img width="700" alt="image" src="https://github.com/user-attachments/assets/ebb1286c-18aa-4801-9e08-44779c08c475">


<br>

## ➕ ETC 
- 개발을 진행하다 보니 Device 도메인의 코드 라인이 많아져서 부득이하게 PR을 나눴습니다.