### PR TITLE
[Feat] 장비(Device) 사용자 권한에 따른 데이터 조회 분기 처리

### DIFF
--- a/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
@@ -3,10 +3,12 @@ package sandbox.semo.application.device.controller;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +18,7 @@ import sandbox.semo.application.device.service.DeviceService;
 import sandbox.semo.application.security.authentication.MemberPrincipalDetails;
 import sandbox.semo.domain.device.dto.request.DeviceRegister;
 import sandbox.semo.domain.device.dto.request.DataBaseInfo;
+import sandbox.semo.domain.device.dto.response.DeviceInfo;
 
 @Log4j2
 @RestController
@@ -39,6 +42,20 @@ public class DeviceController {
     ) {
         deviceService.register(memberDetails.getMember().getCompany(), request);
         return ApiResponse.successResponse(OK, "성공적으로 DEVICE가 등록되었습니다.");
+    }
+
+    @GetMapping
+    public ApiResponse<?> getDeviceInfoByCompany(
+            @AuthenticationPrincipal MemberPrincipalDetails memberDetails) {
+        List<DeviceInfo> data = deviceService.getDeviceInfo(
+                memberDetails.getMember().getRole(),
+                memberDetails.getMember().getCompany()
+        );
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 DEVICE가 조회 되었습니다.",
+                data.isEmpty() ? "조회된 데이터가 없습니다." : data
+        );
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/controller/DeviceController.java
@@ -45,17 +45,13 @@ public class DeviceController {
     }
 
     @GetMapping
-    public ApiResponse<?> getDeviceInfoByCompany(
+    public ApiResponse<List<DeviceInfo>> getDeviceInfoByCompany(
             @AuthenticationPrincipal MemberPrincipalDetails memberDetails) {
         List<DeviceInfo> data = deviceService.getDeviceInfo(
                 memberDetails.getMember().getRole(),
                 memberDetails.getMember().getCompany()
         );
-        return ApiResponse.successResponse(
-                OK,
-                "성공적으로 DEVICE가 조회 되었습니다.",
-                data.isEmpty() ? "조회된 데이터가 없습니다." : data
-        );
+        return ApiResponse.successResponse(OK, "성공적으로 DEVICE가 조회 되었습니다.", data);
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceService.java
@@ -1,13 +1,18 @@
 package sandbox.semo.application.device.service;
 
+import java.util.List;
 import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.device.dto.request.DeviceRegister;
 import sandbox.semo.domain.device.dto.request.DataBaseInfo;
+import sandbox.semo.domain.device.dto.response.DeviceInfo;
+import sandbox.semo.domain.member.entity.Role;
 
 public interface DeviceService {
 
     boolean healthCheck(DataBaseInfo request);
 
     void register(Company company, DeviceRegister request);
+
+    List<DeviceInfo> getDeviceInfo(Role role, Company company);
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/device/service/DeviceServiceImpl.java
@@ -5,6 +5,8 @@ import static sandbox.semo.application.device.exception.DeviceErrorCode.*;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -14,8 +16,10 @@ import sandbox.semo.application.device.exception.DeviceBusinessException;
 import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.device.dto.request.DeviceRegister;
 import sandbox.semo.domain.device.dto.request.DataBaseInfo;
+import sandbox.semo.domain.device.dto.response.DeviceInfo;
 import sandbox.semo.domain.device.entity.Device;
 import sandbox.semo.domain.device.repository.DeviceRepository;
+import sandbox.semo.domain.member.entity.Role;
 
 @Service
 @Log4j2
@@ -24,6 +28,24 @@ import sandbox.semo.domain.device.repository.DeviceRepository;
 public class DeviceServiceImpl implements DeviceService {
 
     private final DeviceRepository deviceRepository;
+
+    @Override
+    public List<DeviceInfo> getDeviceInfo(Role role, Company company) {
+        List<DeviceInfo> data = new ArrayList<>();
+        switch (role) {
+            case ADMIN, USER -> data = readDeviceOfAdminAndUserRole(company);
+            case SUPER -> data = readDeviceOfSuperRole(company);
+        }
+        return data;
+    }
+
+    private List<DeviceInfo> readDeviceOfAdminAndUserRole(Company company) {
+        return deviceRepository.findByCompanyId(company.getId());
+    }
+
+    private List<DeviceInfo> readDeviceOfSuperRole(Company company) {
+        return deviceRepository.findAllExceptByCompanyId(company.getId());
+    }
 
     @Transactional
     @Override

--- a/semo-core/src/main/java/sandbox/semo/domain/device/dto/response/DeviceInfo.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/dto/response/DeviceInfo.java
@@ -1,0 +1,28 @@
+package sandbox.semo.domain.device.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import sandbox.semo.domain.device.entity.DatabaseType;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeviceInfo {
+
+    private String deviceAlias;
+
+    private DatabaseType type;
+
+    private String ip;
+
+    private Long port;
+
+    private String sid;
+
+    private Boolean status;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/device/repository/DeviceRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/repository/DeviceRepository.java
@@ -1,8 +1,24 @@
 package sandbox.semo.domain.device.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sandbox.semo.domain.device.dto.response.DeviceInfo;
 import sandbox.semo.domain.device.entity.Device;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+    @Query("SELECT new sandbox.semo.domain.device.dto.response.DeviceInfo" +
+            "(d.deviceAlias, d.type, d.ip, d.port, d.sid, d.status, d.updatedAt) " +
+            "FROM Device d " +
+            "WHERE d.company.id = :companyId")
+    List<DeviceInfo> findByCompanyId(@Param("companyId") Long companyId);
+
+    @Query("SELECT new sandbox.semo.domain.device.dto.response.DeviceInfo" +
+            "(d.deviceAlias, d.type, d.ip, d.port, d.sid, d.status, d.updatedAt) " +
+            "FROM Device d " +
+            "WHERE d.company.id <> :companyId")
+    List<DeviceInfo> findAllExceptByCompanyId(@Param("companyId") Long companyId);
 
 }


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #6 

<br>

## 💡 Key Changes
### 등록된 장비의 정보를 권한에 따라 대상 장비 리스트를 조회하는 API 구현
- `switch`문을 활용하여 권한에 대한 비즈니스 로직 분기 처리로 모든 사용자는 동일한 API URL을 사용
- API url: `[GET]  /api/v1/device`

🆔 **`ADMIN`, `USER` 권한을 가진 계정**
- 자신이 속한 회사의 장비 리스트를 조회
>```sql
>SELECT DEVICE_ALIAS, TYPE, IP, PORT, SID, STATUS, UPDATE_AT
>  FROM DEVICES
> WHERE COMPANY_ID = :companyId
>```

🆔 **`SUPER` 권한을 가진 계정**
- 자신의 정보를 제외한 모든 장비 리스트를 조회
- SUPER 권한은 모니터링 서비스를 사용하는 목적이 아니라 `ADMIN` 계정을 관리하는 목적이 크므로, 자신을 제외한 모든 데이터를 조회하여 데이터를 관리할 수 있도록 구현하였습니다.
>```sql
>SELECT DEVICE_ALIAS, TYPE, IP, PORT, SID, STATUS, UPDATE_AT
>  FROM DEVICES
> WHERE COMPANY_ID <> :companyId
>```

- 조회된 목록 데이터가 없을시 빈 리스트를 반환
<img width="700" alt="image" src="https://github.com/user-attachments/assets/1df2ddf5-f639-45bc-9e29-30aaf9c41477">

<br>

## ➕ ETC 
- 현재 개발 시점에는 단순 테이블의 데이터에서 필요한 컬럼만 조회하도록 되어 있습니다. 
- 데이터 수집 API가 완료되면 해당 API는 추가 개발이 이뤄질 예정입니다.
- 클라이언트에 보내줘야할 데이터가 데이터 수집 테이블에 존재하여 수집 API 개발이 진행된 이후 조회 쿼리 수정과 응답 DTO 및 로직이 수정되어야 합니다.
- 현재 개발에는 페이지네이션 처리는 되어 있지 않습니다.
