### PR TITLE
[Feat] MemberForm 등록, 목록조회 ,관리자 승인처리 API 구현 및  DTO유효성 검증 추가

### DIFF
--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/CompanyFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/CompanyFormController.java
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.form.service.CompanyFormService;
+import sandbox.semo.domain.form.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.form.dto.request.CompanyFormRegister;
-import sandbox.semo.domain.form.dto.request.CompanyFormUpdate;
 import sandbox.semo.domain.form.dto.response.CompanyFormList;
 
 @Log4j2
@@ -56,7 +56,7 @@ public class CompanyFormController {
     @PreAuthorize("hasRole('SUPER')")
     @PatchMapping
     public ApiResponse<String> formUpdate(
-            @RequestBody @Valid CompanyFormUpdate updateForm) {
+            @RequestBody @Valid CompanyFormDecision updateForm) {
         String data = companyFormService.updateStatus(updateForm);
 
         return ApiResponse.successResponse(

--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/CompanyFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/CompanyFormController.java
@@ -19,7 +19,7 @@ import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.form.service.CompanyFormService;
 import sandbox.semo.domain.form.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.form.dto.request.CompanyFormRegister;
-import sandbox.semo.domain.form.dto.response.CompanyFormList;
+import sandbox.semo.domain.form.dto.response.CompanyFormInfo;
 
 @Log4j2
 @RestController
@@ -40,11 +40,11 @@ public class CompanyFormController {
 
     @PreAuthorize("hasRole('SUPER')")
     @GetMapping
-    public ApiResponse<Page<CompanyFormList>> registerList(
+    public ApiResponse<Page<CompanyFormInfo>> registerList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
-        Page<CompanyFormList> companyFormLists = companyFormService.findAllForms(page, size);
+        Page<CompanyFormInfo> companyFormLists = companyFormService.findAllForms(page, size);
         return ApiResponse.successResponse(
                 OK,
                 "성공적으로 목록을 조회하였습니다.",

--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
@@ -1,0 +1,32 @@
+package sandbox.semo.application.form.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sandbox.semo.application.common.response.ApiResponse;
+import sandbox.semo.application.form.service.MemberFormService;
+import sandbox.semo.domain.form.dto.request.MemberFormRegister;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/form/member")
+public class MemberFormController {
+
+    private final MemberFormService memberFormService;
+
+    @PostMapping
+    public ApiResponse<Void> formRegister(@RequestBody @Valid MemberFormRegister registerForm) {
+        memberFormService.formRegister(registerForm);
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 폼을 제출하였습니다.");
+    }
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
@@ -8,6 +8,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.form.service.MemberFormService;
+import sandbox.semo.domain.form.dto.request.MemberFormDecision;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
 import sandbox.semo.domain.form.dto.response.MemberFormList;
 
@@ -47,6 +49,16 @@ public class MemberFormController {
                 data
         );
 
+    }
+
+    @PreAuthorize("hasRole('SUPER')")
+    @PatchMapping
+    public ApiResponse<String> formUpdate(MemberFormDecision formDecision) {
+        String data = memberFormService.updateForm(formDecision);
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 처리되었습니다.",
+                data);
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
@@ -5,13 +5,18 @@ import static org.springframework.http.HttpStatus.OK;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.form.service.MemberFormService;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
+import sandbox.semo.domain.form.dto.response.MemberFormList;
 
 @Log4j2
 @RestController
@@ -27,6 +32,21 @@ public class MemberFormController {
         return ApiResponse.successResponse(
                 OK,
                 "성공적으로 폼을 제출하였습니다.");
+    }
+
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping
+    public ApiResponse<Page<MemberFormList>> formList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<MemberFormList> data = memberFormService.findAllForms(page, size);
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 목록을 조회하였습니다.",
+                data
+        );
+
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
@@ -18,7 +18,7 @@ import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.form.service.MemberFormService;
 import sandbox.semo.domain.form.dto.request.MemberFormDecision;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
-import sandbox.semo.domain.form.dto.response.MemberFormList;
+import sandbox.semo.domain.form.dto.response.MemberFormInfo;
 
 @Log4j2
 @RestController
@@ -38,11 +38,11 @@ public class MemberFormController {
 
     @PreAuthorize("hasRole('SUPER')")
     @GetMapping
-    public ApiResponse<Page<MemberFormList>> formList(
+    public ApiResponse<Page<MemberFormInfo>> getFormList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
-        Page<MemberFormList> data = memberFormService.findAllForms(page, size);
+        Page<MemberFormInfo> data = memberFormService.findAllForms(page, size);
         return ApiResponse.successResponse(
                 OK,
                 "성공적으로 목록을 조회하였습니다.",

--- a/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/controller/MemberFormController.java
@@ -53,7 +53,7 @@ public class MemberFormController {
 
     @PreAuthorize("hasRole('SUPER')")
     @PatchMapping
-    public ApiResponse<String> formUpdate(MemberFormDecision formDecision) {
+    public ApiResponse<String> formUpdate(@RequestBody @Valid MemberFormDecision formDecision) {
         String data = memberFormService.updateForm(formDecision);
         return ApiResponse.successResponse(
                 OK,

--- a/semo-api/src/main/java/sandbox/semo/application/form/exception/MemberFormBusinessException.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/exception/MemberFormBusinessException.java
@@ -1,0 +1,14 @@
+package sandbox.semo.application.form.exception;
+
+import lombok.Data;
+
+@Data
+public class MemberFormBusinessException extends RuntimeException {
+
+    private final MemberFormErrorCode memberFormErrorCode;
+
+    public MemberFormBusinessException(MemberFormErrorCode memberFormErrorCode) {
+        super(memberFormErrorCode.getMessage());
+        this.memberFormErrorCode = memberFormErrorCode;
+    }
+}

--- a/semo-api/src/main/java/sandbox/semo/application/form/exception/MemberFormErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/exception/MemberFormErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberFormErrorCode {
 
-    COMPANY_NOT_EXIST(NOT_FOUND, "존재하지 않는 회사입니다.");
+    COMPANY_NOT_EXIST(NOT_FOUND, "존재하지 않는 회사입니다."),
+    FORM_DOES_NOT_EXIST(NOT_FOUND, "해당 ID의 폼을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/semo-api/src/main/java/sandbox/semo/application/form/exception/MemberFormErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/exception/MemberFormErrorCode.java
@@ -1,0 +1,18 @@
+package sandbox.semo.application.form.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberFormErrorCode {
+
+    COMPANY_NOT_EXIST(NOT_FOUND, "존재하지 않는 회사입니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormService.java
@@ -1,8 +1,8 @@
 package sandbox.semo.application.form.service;
 
 import org.springframework.data.domain.Page;
+import sandbox.semo.domain.form.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.form.dto.request.CompanyFormRegister;
-import sandbox.semo.domain.form.dto.request.CompanyFormUpdate;
 import sandbox.semo.domain.form.dto.response.CompanyFormList;
 
 public interface CompanyFormService {
@@ -11,5 +11,5 @@ public interface CompanyFormService {
 
     Page<CompanyFormList> findAllForms(int page, int size);
 
-    String updateStatus(CompanyFormUpdate request);
+    String updateStatus(CompanyFormDecision request);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormService.java
@@ -3,13 +3,13 @@ package sandbox.semo.application.form.service;
 import org.springframework.data.domain.Page;
 import sandbox.semo.domain.form.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.form.dto.request.CompanyFormRegister;
-import sandbox.semo.domain.form.dto.response.CompanyFormList;
+import sandbox.semo.domain.form.dto.response.CompanyFormInfo;
 
 public interface CompanyFormService {
 
     void formRegister(CompanyFormRegister companyFormRegister);
 
-    Page<CompanyFormList> findAllForms(int page, int size);
+    Page<CompanyFormInfo> findAllForms(int page, int size);
 
     String updateStatus(CompanyFormDecision request);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sandbox.semo.application.form.exception.CompanyFormBusinessException;
 import sandbox.semo.domain.company.repository.CompanyRepository;
+import sandbox.semo.domain.form.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.form.dto.request.CompanyFormRegister;
-import sandbox.semo.domain.form.dto.request.CompanyFormUpdate;
 import sandbox.semo.domain.form.dto.response.CompanyFormList;
 import sandbox.semo.domain.form.entity.CompanyForm;
 import sandbox.semo.domain.form.entity.Status;
@@ -73,7 +73,7 @@ public class CompanyFormServiceImpl implements CompanyFormService {
 
     @Override
     @Transactional
-    public String updateStatus(CompanyFormUpdate request) {
+    public String updateStatus(CompanyFormDecision request) {
         CompanyForm companyForm = companyFormRepository.findById(request.getFormId())
                 .orElseThrow(() -> new CompanyFormBusinessException(FORM_DOES_NOT_EXIST));
 

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
@@ -16,7 +16,7 @@ import sandbox.semo.application.form.exception.CompanyFormBusinessException;
 import sandbox.semo.domain.company.repository.CompanyRepository;
 import sandbox.semo.domain.form.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.form.dto.request.CompanyFormRegister;
-import sandbox.semo.domain.form.dto.response.CompanyFormList;
+import sandbox.semo.domain.form.dto.response.CompanyFormInfo;
 import sandbox.semo.domain.form.entity.CompanyForm;
 import sandbox.semo.domain.form.entity.Status;
 import sandbox.semo.domain.form.repository.CompanyFormRepository;
@@ -50,19 +50,21 @@ public class CompanyFormServiceImpl implements CompanyFormService {
         }
     }
 
-    /*
-     * TO DO : 0번째 에지부터 data가 없으면, 빈배열
+    //TODO:
+
+    /**
+     * TODO: 0번째 에지부터 data가 없으면, 빈배열
      * totalPage를 넘어갔을 때 data가 없으면 예외처리 발생
-     */
+     **/
     @Override
-    public Page<CompanyFormList> findAllForms(int page, int size) {
+    public Page<CompanyFormInfo> findAllForms(int page, int size) {
         List<Sort.Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.desc("requestDate"));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
         Page<CompanyForm> companyFormPage = companyFormRepository.findAll(pageable);
 
-        return companyFormPage.map(companyForm -> CompanyFormList.builder()
+        return companyFormPage.map(companyForm -> CompanyFormInfo.builder()
                 .formId(companyForm.getId())
                 .companyName(companyForm.getCompanyName())
                 .ownerName(companyForm.getOwnerName())

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
@@ -77,7 +77,7 @@ public class CompanyFormServiceImpl implements CompanyFormService {
         CompanyForm companyForm = companyFormRepository.findById(request.getFormId())
                 .orElseThrow(() -> new CompanyFormBusinessException(FORM_DOES_NOT_EXIST));
 
-        Status newStatus = Status.valueOf(request.getUpdateStatus().toUpperCase());
+        Status newStatus = Status.valueOf(request.getDecisionStatus().toUpperCase());
         companyForm.changeStatus(newStatus);
         return companyFormRepository.save(companyForm).getStatus().toString();
 

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/CompanyFormServiceImpl.java
@@ -50,7 +50,10 @@ public class CompanyFormServiceImpl implements CompanyFormService {
         }
     }
 
-
+    /*
+     * TO DO : 0번째 에지부터 data가 없으면, 빈배열
+     * totalPage를 넘어갔을 때 data가 없으면 예외처리 발생
+     */
     @Override
     public Page<CompanyFormList> findAllForms(int page, int size) {
         List<Sort.Order> sorts = new ArrayList<>();

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
@@ -3,13 +3,13 @@ package sandbox.semo.application.form.service;
 import org.springframework.data.domain.Page;
 import sandbox.semo.domain.form.dto.request.MemberFormDecision;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
-import sandbox.semo.domain.form.dto.response.MemberFormList;
+import sandbox.semo.domain.form.dto.response.MemberFormInfo;
 
 public interface MemberFormService {
 
     void formRegister(MemberFormRegister request);
 
-    Page<MemberFormList> findAllForms(int page, int size);
+    Page<MemberFormInfo> findAllForms(int page, int size);
 
     String updateForm(MemberFormDecision request);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
@@ -1,8 +1,12 @@
 package sandbox.semo.application.form.service;
 
+import org.springframework.data.domain.Page;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
+import sandbox.semo.domain.form.dto.response.MemberFormList;
 
 public interface MemberFormService {
 
     void formRegister(MemberFormRegister request);
+
+    Page<MemberFormList> findAllForms(int page, int size);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
@@ -1,6 +1,7 @@
 package sandbox.semo.application.form.service;
 
 import org.springframework.data.domain.Page;
+import sandbox.semo.domain.form.dto.request.MemberFormDecision;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
 import sandbox.semo.domain.form.dto.response.MemberFormList;
 
@@ -9,4 +10,6 @@ public interface MemberFormService {
     void formRegister(MemberFormRegister request);
 
     Page<MemberFormList> findAllForms(int page, int size);
+
+    String updateForm(MemberFormDecision request);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormService.java
@@ -1,0 +1,8 @@
+package sandbox.semo.application.form.service;
+
+import sandbox.semo.domain.form.dto.request.MemberFormRegister;
+
+public interface MemberFormService {
+
+    void formRegister(MemberFormRegister request);
+}

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -76,7 +76,9 @@ public class MemberFormServiceImpl implements MemberFormService {
 
         Status newStatus = Status.valueOf(request.getDecisionStatus().toUpperCase());
         memberForm.changeStatus(newStatus);
-        return memberFormRepository.save(memberForm).getStatus().toString();
+        MemberForm saveForm = memberFormRepository.save(memberForm);
+        log.info(">>> [ ✅ 고객사 회원가입 폼을 관리자가 최종 처리하였습니다. ]");
+        return saveForm.getStatus().toString();
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -19,7 +19,7 @@ import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.company.repository.CompanyRepository;
 import sandbox.semo.domain.form.dto.request.MemberFormDecision;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
-import sandbox.semo.domain.form.dto.response.MemberFormList;
+import sandbox.semo.domain.form.dto.response.MemberFormInfo;
 import sandbox.semo.domain.form.entity.MemberForm;
 import sandbox.semo.domain.form.entity.Status;
 import sandbox.semo.domain.form.repository.MemberFormRepository;
@@ -48,19 +48,19 @@ public class MemberFormServiceImpl implements MemberFormService {
         log.info(">>> [ ✅ 고객사 회원가입 폼이 성공적으로 등록되었습니다. ]");
     }
 
-    /*
-     * TO DO : 0번째 에지부터 data가 없으면, 빈배열
+    /**
+     * TODO: 0번째 에지부터 data가 없으면, 빈배열
      * totalPage를 넘어갔을 때 data가 없으면 예외처리 발생
-     */
+     **/
     @Override
-    public Page<MemberFormList> findAllForms(int page, int size) {
+    public Page<MemberFormInfo> findAllForms(int page, int size) {
         List<Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.desc("requestDate"));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
         Page<MemberForm> memberFormPage = memberFormRepository.findAll(pageable);
 
-        return memberFormPage.map(memberForm -> MemberFormList.builder()
+        return memberFormPage.map(memberForm -> MemberFormInfo.builder()
                 .formId(memberForm.getId())
                 .companyName(memberForm.getCompanyName())
                 .ownerName(memberForm.getOwnerName())

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -1,6 +1,7 @@
 package sandbox.semo.application.form.service;
 
 import static sandbox.semo.application.form.exception.MemberFormErrorCode.COMPANY_NOT_EXIST;
+import static sandbox.semo.application.form.exception.MemberFormErrorCode.FORM_DOES_NOT_EXIST;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sandbox.semo.application.form.exception.MemberFormBusinessException;
 import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.company.repository.CompanyRepository;
+import sandbox.semo.domain.form.dto.request.MemberFormDecision;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
 import sandbox.semo.domain.form.dto.response.MemberFormList;
 import sandbox.semo.domain.form.entity.MemberForm;
@@ -63,6 +65,18 @@ public class MemberFormServiceImpl implements MemberFormService {
                 .requestDate(memberForm.getRequestDate())
                 .approvedAt(memberForm.getApprovedAt())
                 .build());
+    }
+
+
+    @Override
+    @Transactional
+    public String updateForm(MemberFormDecision request) {
+        MemberForm memberForm = memberFormRepository.findById(request.getFormId())
+                .orElseThrow(() -> new MemberFormBusinessException(FORM_DOES_NOT_EXIST));
+
+        Status newStatus = Status.valueOf(request.getDecisionStatus().toUpperCase());
+        memberForm.changeStatus(newStatus);
+        return memberFormRepository.save(memberForm).getStatus().toString();
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -1,0 +1,40 @@
+package sandbox.semo.application.form.service;
+
+import static sandbox.semo.application.form.exception.MemberFormErrorCode.COMPANY_NOT_EXIST;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sandbox.semo.application.form.exception.MemberFormBusinessException;
+import sandbox.semo.domain.company.entity.Company;
+import sandbox.semo.domain.company.repository.CompanyRepository;
+import sandbox.semo.domain.form.dto.request.MemberFormRegister;
+import sandbox.semo.domain.form.entity.MemberForm;
+import sandbox.semo.domain.form.entity.Status;
+import sandbox.semo.domain.form.repository.MemberFormRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberFormServiceImpl implements MemberFormService {
+
+    private final MemberFormRepository memberFormRepository;
+    private final CompanyRepository companyRepository;
+    
+    @Override
+    @Transactional
+    public void formRegister(MemberFormRegister request) {
+        Company requestCompany = companyRepository.findById(request.getCompanyId())
+                .orElseThrow(() -> new MemberFormBusinessException(COMPANY_NOT_EXIST));
+
+        MemberForm memberForm = MemberForm.builder()
+                .companyName(requestCompany.getCompanyName())
+                .email(request.getEmail())
+                .ownerName(request.getOwnerName())
+                .status(Status.PENDING)
+                .build();
+
+        memberFormRepository.save(memberForm);
+    }
+
+}

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -48,6 +48,10 @@ public class MemberFormServiceImpl implements MemberFormService {
         log.info(">>> [ ✅ 고객사 회원가입 폼이 성공적으로 등록되었습니다. ]");
     }
 
+    /*
+     * TO DO : 0번째 에지부터 data가 없으면, 빈배열
+     * totalPage를 넘어갔을 때 data가 없으면 예외처리 발생
+     */
     @Override
     public Page<MemberFormList> findAllForms(int page, int size) {
         List<Order> sorts = new ArrayList<>();

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -2,14 +2,22 @@ package sandbox.semo.application.form.service;
 
 import static sandbox.semo.application.form.exception.MemberFormErrorCode.COMPANY_NOT_EXIST;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sandbox.semo.application.form.exception.MemberFormBusinessException;
 import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.company.repository.CompanyRepository;
 import sandbox.semo.domain.form.dto.request.MemberFormRegister;
+import sandbox.semo.domain.form.dto.response.MemberFormList;
 import sandbox.semo.domain.form.entity.MemberForm;
 import sandbox.semo.domain.form.entity.Status;
 import sandbox.semo.domain.form.repository.MemberFormRepository;
@@ -36,6 +44,25 @@ public class MemberFormServiceImpl implements MemberFormService {
                 .status(Status.PENDING)
                 .build());
         log.info(">>> [ ✅ 고객사 회원가입 폼이 성공적으로 등록되었습니다. ]");
+    }
+
+    @Override
+    public Page<MemberFormList> findAllForms(int page, int size) {
+        List<Order> sorts = new ArrayList<>();
+        sorts.add(Sort.Order.desc("requestDate"));
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
+        Page<MemberForm> memberFormPage = memberFormRepository.findAll(pageable);
+
+        return memberFormPage.map(memberForm -> MemberFormList.builder()
+                .formId(memberForm.getId())
+                .companyName(memberForm.getCompanyName())
+                .ownerName(memberForm.getOwnerName())
+                .email(memberForm.getEmail())
+                .status(memberForm.getStatus())
+                .requestDate(memberForm.getRequestDate())
+                .approvedAt(memberForm.getApprovedAt())
+                .build());
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/form/service/MemberFormServiceImpl.java
@@ -3,6 +3,7 @@ package sandbox.semo.application.form.service;
 import static sandbox.semo.application.form.exception.MemberFormErrorCode.COMPANY_NOT_EXIST;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sandbox.semo.application.form.exception.MemberFormBusinessException;
@@ -14,27 +15,27 @@ import sandbox.semo.domain.form.entity.Status;
 import sandbox.semo.domain.form.repository.MemberFormRepository;
 
 @Service
+@Log4j2
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberFormServiceImpl implements MemberFormService {
 
     private final MemberFormRepository memberFormRepository;
     private final CompanyRepository companyRepository;
-    
+
     @Override
     @Transactional
     public void formRegister(MemberFormRegister request) {
         Company requestCompany = companyRepository.findById(request.getCompanyId())
                 .orElseThrow(() -> new MemberFormBusinessException(COMPANY_NOT_EXIST));
 
-        MemberForm memberForm = MemberForm.builder()
+        memberFormRepository.save(MemberForm.builder()
                 .companyName(requestCompany.getCompanyName())
                 .email(request.getEmail())
                 .ownerName(request.getOwnerName())
                 .status(Status.PENDING)
-                .build();
-
-        memberFormRepository.save(memberForm);
+                .build());
+        log.info(">>> [ ✅ 고객사 회원가입 폼이 성공적으로 등록되었습니다. ]");
     }
 
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/CompanyFormDecision.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/CompanyFormDecision.java
@@ -5,11 +5,11 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class CompanyFormUpdate {
+public class CompanyFormDecision {
 
     @NotNull
     private Long formId;
 
     @NotBlank
-    private String updateStatus;
+    private String decisionStatus;
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/CompanyFormRegister.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/CompanyFormRegister.java
@@ -1,5 +1,6 @@
 package sandbox.semo.domain.form.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -13,6 +14,7 @@ public class CompanyFormRegister {
     @NotBlank
     private String taxId;
 
+    @Email
     @NotBlank
     private String email;
 

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/MemberFormDecision.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/MemberFormDecision.java
@@ -1,0 +1,16 @@
+package sandbox.semo.domain.form.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class MemberFormDecision {
+
+    @NotNull
+    private Long formId;
+
+    @NotBlank
+    private String decisionStatus;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/MemberFormRegister.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/MemberFormRegister.java
@@ -2,12 +2,13 @@ package sandbox.semo.domain.form.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class MemberFormRegister {
 
-    @NotBlank
+    @NotNull
     private Long companyId;
 
     @Email

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/MemberFormRegister.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/request/MemberFormRegister.java
@@ -1,0 +1,19 @@
+package sandbox.semo.domain.form.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class MemberFormRegister {
+
+    @NotBlank
+    private Long companyId;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String ownerName;
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/response/CompanyFormInfo.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/response/CompanyFormInfo.java
@@ -2,17 +2,19 @@ package sandbox.semo.domain.form.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sandbox.semo.domain.form.entity.Status;
 
 @Getter
-@NoArgsConstructor
-public class MemberFormList {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyFormInfo {
 
     private Long formId;
     private String companyName;
+    private String taxId;
     private String ownerName;
     private String email;
     private Status status;
@@ -24,10 +26,11 @@ public class MemberFormList {
     private LocalDateTime approvedAt;
 
     @Builder
-    public MemberFormList(Long formId, String companyName, String ownerName,
+    public CompanyFormInfo(Long formId, String companyName, String taxId, String ownerName,
             String email, Status status, LocalDateTime requestDate, LocalDateTime approvedAt) {
         this.formId = formId;
         this.companyName = companyName;
+        this.taxId = taxId;
         this.ownerName = ownerName;
         this.email = email;
         this.status = status;

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/response/MemberFormInfo.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/response/MemberFormInfo.java
@@ -1,20 +1,19 @@
 package sandbox.semo.domain.form.dto.response;
 
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sandbox.semo.domain.form.entity.Status;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CompanyFormList {
+@NoArgsConstructor
+public class MemberFormInfo {
 
     private Long formId;
     private String companyName;
-    private String taxId;
     private String ownerName;
     private String email;
     private Status status;
@@ -26,11 +25,10 @@ public class CompanyFormList {
     private LocalDateTime approvedAt;
 
     @Builder
-    public CompanyFormList(Long formId, String companyName, String taxId, String ownerName,
+    public MemberFormInfo(Long formId, String companyName, String ownerName,
             String email, Status status, LocalDateTime requestDate, LocalDateTime approvedAt) {
         this.formId = formId;
         this.companyName = companyName;
-        this.taxId = taxId;
         this.ownerName = ownerName;
         this.email = email;
         this.status = status;

--- a/semo-core/src/main/java/sandbox/semo/domain/form/dto/response/MemberFormList.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/dto/response/MemberFormList.java
@@ -1,0 +1,37 @@
+package sandbox.semo.domain.form.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sandbox.semo.domain.form.entity.Status;
+
+@Getter
+@NoArgsConstructor
+public class MemberFormList {
+
+    private Long formId;
+    private String companyName;
+    private String ownerName;
+    private String email;
+    private Status status;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime requestDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime approvedAt;
+
+    @Builder
+    public MemberFormList(Long formId, String companyName, String ownerName,
+            String email, Status status, LocalDateTime requestDate, LocalDateTime approvedAt) {
+        this.formId = formId;
+        this.companyName = companyName;
+        this.ownerName = ownerName;
+        this.email = email;
+        this.status = status;
+        this.requestDate = requestDate;
+        this.approvedAt = approvedAt;
+    }
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/form/entity/MemberForm.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/form/entity/MemberForm.java
@@ -32,4 +32,9 @@ public class MemberForm extends BaseForm {
         this.status = status;
     }
 
+    public void changeStatus(Status newStatus) {
+        this.status = newStatus;
+        this.markAsApproved();
+    }
+
 }


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #19

<br>

## 💡 Key Changes

### 1️⃣  '고객사 회원가입 요청폼' 등록 API
-  `companyId`를 검증 후, MemberForm 테이블에 등록하는  API 
- API url : `/api/v1/form/member`


<br>

### 2️⃣  '고객사 회원가입 요청폼' 목록조회  API
- MemberForm 요청 목록들을 모두 조회합니다. 
>  페이지네이션을 추가하였습니다.(추후 테이블에 데이터가 쌓이는 것을 통해 페이지네이션이 수정될 가능성이 있습니다)

- API url : `/api/v1/form/member?page=0&size=10`
> `page` : `(default) 0`
`size` : `(default)10`

<br>


### 3️⃣  '고객사 회원가입 요청' - 관리자 승인처리 API
- MemberForm 요청 목록을 SUPER가 'APPROVED' 혹은 'DENIED' 중 하나로 처리합니다.
> decisionStatus : 관리자의 승인결과 값입니다.
이 값을 소문자로 보내도 대문자로 변환이 처리가 됩니다.

- API url : `/api/v1/form/member`

<br>


## ✅ Test - PostMan Tool 사용

### 🚀 '고객사 회원가입 폼' 등록 API
![image](https://github.com/user-attachments/assets/d5af5408-4436-4cbb-9fa6-45a7e0f8a30a)

- companyId가 존재하지 않는 경우 (예외처리)
![image](https://github.com/user-attachments/assets/084eb320-0ab3-4e6a-89d6-ff852225d664)



<br>

### 🚀   '고객사 회원가입 요청폼' 목록조회  API

- MemberForm 테이블의 요청목록을 모두 조회합니다(페이지네이션)
![image](https://github.com/user-attachments/assets/1a8d1f52-a511-4165-93c1-3e0a296f7638)

<br>

- 페이지가 존재하지 않을 경우 `Content`는 빈배열로 조회됩니다.
![image](https://github.com/user-attachments/assets/0419860c-10e7-452c-95cf-32da2edb3e81)



<br>

### 🚀    '고객사 회원가입 요청' - 관리자 승인처리 API

- 관리자가 'approved'를 보내 폼을 처리합니다.
![image](https://github.com/user-attachments/assets/303f921f-1973-44c3-8699-84807b55fe9e)

<br>

- 해당 폼이 존재하지 않거나 없을경우 예외메시지를 출력합니다.
![image](https://github.com/user-attachments/assets/6c92eaa7-b75d-4661-b699-9bf30a7dc248)


## ➕ ETC 
> 이후 유저 필터링 목록조회 쿼리 명세서 작성하여 FE 공유 후, QueryDSL과 Jpql 둘 중의 성능 등을 고려하여 BE 분들과 의견을 나눈 후, 회원 도메인 API 개발 진행을 이어서 하겠습니다.

- 즉, 특정 유저 조회 API와 전체 유저 목록조회 API를 하나의 API로 합쳐서 처리할 예정 입니다.
