### PR TITLE
[Feat] 회원가입 및 이메일 중복확인 API 구현

### DIFF
--- a/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
@@ -4,7 +4,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.math.BigDecimal;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class LoginIdGeneratorUtil {
@@ -12,7 +11,6 @@ public class LoginIdGeneratorUtil {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Transactional
     public String generateLoginId(String role, String taxId) {
         String prefix = role.equals("ADMIN") ? "A" : "U";
         String splitTaxId = taxId.replace("-", "");

--- a/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
@@ -1,21 +1,23 @@
 package sandbox.semo.application.common.util;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class LoginIdGeneratorUtil {
 
-    private static int lastNumber = 1;
+    private static final Map<String, AtomicInteger> lastNumberMap = new ConcurrentHashMap<>();
 
     public static String generateLoginId(String role, String taxId) {
-        String prefix = "";
-        if (role.equals("ADMIN")) {
-            prefix = "A";
-        } else {
-            prefix = "U";
-        }
+        String prefix = role.equals("ADMIN") ? "A" : "U";
 
         String splitTaxId = taxId.replace("-", "");
-        String lastTwoDigits = String.format("%02d", lastNumber);
 
-        lastNumber += 1;
+        //taxId가 이미 존재하면 pass, 존재하지 않다면 taxId로 키와 초기값 생성해 Map에 넣어줌
+        AtomicInteger lastNumber = lastNumberMap.computeIfAbsent(splitTaxId,
+                k -> new AtomicInteger(1));
+
+        String lastTwoDigits = String.format("%02d", lastNumber.getAndIncrement());
 
         return prefix + splitTaxId + lastTwoDigits;
     }

--- a/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
@@ -1,0 +1,22 @@
+package sandbox.semo.application.common.util;
+
+public class LoginIdGeneratorUtil {
+
+    private static int lastNumber = 1;
+    
+    public static String generateLoginId(String role, String taxId) {
+        String prefix = "";
+        if (role.equalsIgnoreCase("ADMIN")) {
+            prefix = "A";
+        } else if (role.equalsIgnoreCase("USER")) {
+            prefix = "U";
+        }
+
+        String splitTaxId = taxId.replace("-", "");
+        String lastTwoDigits = String.format("%02d", lastNumber);
+
+        lastNumber += 1;
+
+        return prefix + splitTaxId + lastTwoDigits;
+    }
+}

--- a/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/util/LoginIdGeneratorUtil.java
@@ -3,12 +3,12 @@ package sandbox.semo.application.common.util;
 public class LoginIdGeneratorUtil {
 
     private static int lastNumber = 1;
-    
+
     public static String generateLoginId(String role, String taxId) {
         String prefix = "";
-        if (role.equalsIgnoreCase("ADMIN")) {
+        if (role.equals("ADMIN")) {
             prefix = "A";
-        } else if (role.equalsIgnoreCase("USER")) {
+        } else {
             prefix = "U";
         }
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
@@ -87,7 +87,7 @@ public class MemberController {
         Boolean data = memberService.checkEmailDuplicate(email);
         return ApiResponse.successResponse(
                 OK,
-                "성공적으로 이메일을 조회하였습니다.",
+                "회원가입이 가능한 이메일입니다.",
                 data
         );
     }

--- a/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
@@ -3,11 +3,14 @@ package sandbox.semo.application.member.controller;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +29,7 @@ import sandbox.semo.domain.member.dto.response.MemberFormInfo;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
+@Validated
 public class MemberController {
 
     private final MemberService memberService;
@@ -69,5 +73,17 @@ public class MemberController {
                 OK,
                 "성공적으로 처리되었습니다.",
                 data);
+    }
+
+    @GetMapping("/email-check")
+    public ApiResponse<Boolean> emailValidate(
+            @RequestParam @NotBlank(message = "이메일이 빈 상태 입니다.")
+            @Email(message = "유효한 이메일 형식이 아닙니다.") String email) {
+        Boolean data = memberService.checkEmail(email);
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 이메일을 조회하였습니다.",
+                data
+        );
     }
 }

--- a/semo-api/src/main/java/sandbox/semo/application/member/exception/MemberErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/exception/MemberErrorCode.java
@@ -1,6 +1,7 @@
 package sandbox.semo.application.member.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -18,7 +19,8 @@ public enum MemberErrorCode implements ErrorCode {
     WRONG_PASSWORD(BAD_REQUEST, "입력하신 비밀번호를 다시 확인해 주세요."),
     COMPANY_NOT_EXIST(NOT_FOUND, "존재하지 않는 회사입니다."),
     FORM_DOES_NOT_EXIST(NOT_FOUND, "해당 ID의 폼을 찾을 수 없습니다."),
-    INVALID_COMPANY_SELECTION(BAD_REQUEST, "선택할 수 없는 회사입니다.");
+    INVALID_COMPANY_SELECTION(BAD_REQUEST, "선택할 수 없는 회사입니다."),
+    ALREADY_EXISTS_EMAIL(CONFLICT, "이미 존재하는 이메일 입니다");
 
     private final HttpStatus httpStatus;
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
@@ -5,10 +5,11 @@ import sandbox.semo.domain.member.dto.request.MemberFormDecision;
 import sandbox.semo.domain.member.dto.request.MemberFormRegister;
 import sandbox.semo.domain.member.dto.request.MemberRegister;
 import sandbox.semo.domain.member.dto.response.MemberFormInfo;
+import sandbox.semo.domain.member.entity.Role;
 
 public interface MemberService {
 
-    void register(MemberRegister request);
+    String register(MemberRegister request, Role role);
 
     void formRegister(MemberFormRegister request);
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
@@ -15,4 +15,6 @@ public interface MemberService {
     Page<MemberFormInfo> findAllForms(int page, int size);
 
     String updateForm(MemberFormDecision request);
+
+    Boolean checkEmail(String email);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
@@ -17,5 +17,5 @@ public interface MemberService {
 
     String updateForm(MemberFormDecision request);
 
-    Boolean checkEmail(String email);
+    Boolean checkEmailDuplicate(String email);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
@@ -117,5 +117,10 @@ public class MemberServiceImpl implements MemberService {
         return saveForm.getFormStatus().toString();
     }
 
+    @Override
+    public Boolean checkEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package sandbox.semo.application.member.service;
 
+import static sandbox.semo.application.member.exception.MemberErrorCode.ALREADY_EXISTS_EMAIL;
 import static sandbox.semo.application.member.exception.MemberErrorCode.COMPANY_NOT_EXIST;
 import static sandbox.semo.application.member.exception.MemberErrorCode.FORM_DOES_NOT_EXIST;
 import static sandbox.semo.application.member.exception.MemberErrorCode.INVALID_COMPANY_SELECTION;
@@ -119,7 +120,10 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Boolean checkEmail(String email) {
-        return memberRepository.existsByEmail(email);
+        if (memberRepository.existsByEmail(email)) {
+            throw new MemberBusinessException(ALREADY_EXISTS_EMAIL);
+        }
+        return true;
     }
 
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
@@ -65,6 +65,7 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     @Override
     public void formRegister(MemberFormRegister request) {
+        checkEmailDuplicate(request.getEmail());
         if (request.getCompanyId() == 1L) {
             throw new MemberBusinessException(INVALID_COMPANY_SELECTION);
         }
@@ -119,7 +120,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Boolean checkEmail(String email) {
+    public Boolean checkEmailDuplicate(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new MemberBusinessException(ALREADY_EXISTS_EMAIL);
         }

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
@@ -17,8 +17,8 @@ import org.springframework.data.domain.Sort.Order;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sandbox.semo.application.common.util.LoginIdGeneratorUtil;
 import sandbox.semo.application.member.exception.MemberBusinessException;
+import sandbox.semo.application.member.service.helper.LoginIdGenerator;
 import sandbox.semo.domain.common.entity.FormStatus;
 import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.company.repository.CompanyRepository;
@@ -43,7 +43,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberFormRepository memberFormRepository;
     private final CompanyRepository companyRepository;
     private final PasswordEncoder passwordEncoder;
-    private final LoginIdGeneratorUtil loginIdGeneratorUtil;
+    private final LoginIdGenerator loginIdGenerator;
 
     private static final String DEFAULT_PASSWORD = "0000";
 
@@ -74,7 +74,7 @@ public class MemberServiceImpl implements MemberService {
 
     private String generateLoginId(boolean isSuperRole, Company company) {
         String rolePrefix = isSuperRole ? Role.ADMIN.toString() : Role.USER.toString();
-        return loginIdGeneratorUtil.generateLoginId(rolePrefix, company.getTaxId());
+        return loginIdGenerator.generateLoginId(rolePrefix, company.getTaxId());
     }
 
     private Role determineRole(boolean isSuperRole) {

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
@@ -43,6 +43,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberFormRepository memberFormRepository;
     private final CompanyRepository companyRepository;
     private final PasswordEncoder passwordEncoder;
+    private final LoginIdGeneratorUtil loginIdGeneratorUtil;
 
     private static final String DEFAULT_PASSWORD = "0000";
 
@@ -73,7 +74,7 @@ public class MemberServiceImpl implements MemberService {
 
     private String generateLoginId(boolean isSuperRole, Company company) {
         String rolePrefix = isSuperRole ? Role.ADMIN.toString() : Role.USER.toString();
-        return LoginIdGeneratorUtil.generateLoginId(rolePrefix, company.getTaxId());
+        return loginIdGeneratorUtil.generateLoginId(rolePrefix, company.getTaxId());
     }
 
     private Role determineRole(boolean isSuperRole) {

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/helper/LoginIdGenerator.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/helper/LoginIdGenerator.java
@@ -1,4 +1,4 @@
-package sandbox.semo.application.common.util;
+package sandbox.semo.application.member.service.helper;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -6,7 +6,7 @@ import java.math.BigDecimal;
 import org.springframework.stereotype.Component;
 
 @Component
-public class LoginIdGeneratorUtil {
+public class LoginIdGenerator {
 
     @PersistenceContext
     private EntityManager entityManager;

--- a/semo-core/src/main/java/sandbox/semo/domain/member/dto/request/MemberRegister.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/member/dto/request/MemberRegister.java
@@ -1,5 +1,7 @@
 package sandbox.semo.domain.member.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -9,16 +11,12 @@ public class MemberRegister {
     @NotNull
     private Long companyId;
 
-    @NotNull
-    private String loginId;
-
-    @NotNull
+    @NotBlank
     private String ownerName;
 
-    @NotNull
-    private String password;
+    @NotBlank
+    @Email
+    private String email;
 
-    @NotNull
-    private String role;
 
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberRepository.java
@@ -7,6 +7,8 @@ import sandbox.semo.domain.member.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginId(String loginId);
+
     Optional<Member> findByLoginIdAndDeletedAtIsNull(String loginId);
 
+    boolean existsByEmail(String email);
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberRepository.java
@@ -10,5 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginIdAndDeletedAtIsNull(String loginId);
 
-    boolean existsByEmail(String email);
+    Boolean existsByEmail(String email);
 }


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #23 

<br>

## 💡 Key Changes

### 1️⃣  이메일 중복확인 API
- 이메일 중복확인을 통해 중복일 경우 예외가 터지고, 중복이 아닐 경우 `true`라는 값이 옵니다. 
- API url : `/api/v1/member/email-check?email=`
> `@requestParam`로 `email` 값을 요구합니다.


<br>

### 2️⃣ 회원가입  API
- 회원가입 성공시  loginId는 '권한 , taxID, 00~99까지 생성 값' 으로 쌓이게 됩니다. 
- `SUPER `일 경우, `ADMIN`을 생성, `ADMIN`일 경우 `USER`를 생성
- API url : `/api/v1/member`

<br>

## ✅ Test - PostMan Tool 사용

### 🚀 이메일 중복확인 API
- 성공시 응답
![image](https://github.com/user-attachments/assets/092e8e78-c605-43df-bfad-1c3eb0642497)

- 실패시 응답 ( 이메일이 이미 존재하는 경우) 
![image](https://github.com/user-attachments/assets/93b61a3a-1842-4668-945c-49fdd92338eb)




### 🚀  회원가입  API

- `ADMIN`이 `USER`를 생성합니다.
![image](https://github.com/user-attachments/assets/a391f459-9be7-4daf-92a0-2425fc704382)


- `SUPER`가 `ADMIN`을 생성합니다.
![image](https://github.com/user-attachments/assets/9fe09239-cc59-4102-b91f-afe718240313)





## ➕ ETC 
> 이후 MemberForm과 Company 연관관계 매핑 및 테이블에 컬럼을 생성하여 '고객사 유저 폼 목록조회' api의 응답 값을 수정할 예정 입니다.
그리고 Member 파트 나머지 API를 생성할 예정 입니다. 
