### PR TITLE
[Feat] 장비별 디바이스 차트 정보 페이지에서 필요한 차트 데이터 조회 API 구현

### DIFF
--- a/semo-api/src/main/java/sandbox/semo/application/monitoring/controller/MonitoringController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/monitoring/controller/MonitoringController.java
@@ -7,11 +7,14 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.monitoring.service.MonitoringService;
 import sandbox.semo.application.security.authentication.JwtMemberDetails;
+import sandbox.semo.domain.monitoring.dto.request.DeviceMonitoring;
+import sandbox.semo.domain.monitoring.dto.response.DetailPageData;
 import sandbox.semo.domain.monitoring.dto.response.SummaryPageData;
 
 @Log4j2
@@ -28,6 +31,17 @@ public class MonitoringController {
             @AuthenticationPrincipal JwtMemberDetails memberDetails) {
         SummaryPageData data = monitoringService.fetchSummaryData(memberDetails.getId());
         return ApiResponse.successResponse(OK, "성공적으로 장비 요약 정보를 조회 하였습니다.", data);
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @GetMapping("/chart")
+    public ApiResponse<DetailPageData> fetchDetailInfo(
+            @RequestBody DeviceMonitoring request,
+            @AuthenticationPrincipal JwtMemberDetails memberDetails
+    ) {
+        Long companyId = memberDetails.getCompanyId();
+        DetailPageData data = monitoringService.fetchDetailData(request, companyId);
+        return ApiResponse.successResponse(OK, "성공적으로 장비 차트 정보를 조회 하였습니다.", data);
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringService.java
@@ -1,9 +1,13 @@
 package sandbox.semo.application.monitoring.service;
 
+import sandbox.semo.domain.monitoring.dto.request.DeviceMonitoring;
+import sandbox.semo.domain.monitoring.dto.response.DetailPageData;
 import sandbox.semo.domain.monitoring.dto.response.SummaryPageData;
 
 public interface MonitoringService {
 
     SummaryPageData fetchSummaryData(Long memberId);
+
+    DetailPageData fetchDetailData(DeviceMonitoring request, Long companyId);
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringServiceImpl.java
@@ -51,7 +51,7 @@ public class MonitoringServiceImpl implements MonitoringService {
         List<MetricSummary> metricSummaryData = findMetricSummaryData(company.getId());
 
         TotalProcessInfo totalProcessInfo = buildTotalProcessInfo(metricSummaryData);
-        Map<String, DeviceConnectInfo> allDevices = buildAllDevicesByCompanyId(metricSummaryData);
+        List<DeviceConnectInfo> allDevices = buildAllDevicesByCompanyId(metricSummaryData);
 
         return SummaryPageData.builder()
                 .companyName(company.getCompanyName())
@@ -138,18 +138,18 @@ public class MonitoringServiceImpl implements MonitoringService {
         return "BLOCKED".equals(metricSummary.getStatus());
     }
 
-    private Map<String, DeviceConnectInfo> buildAllDevicesByCompanyId(List<MetricSummary> data) {
+    private List<DeviceConnectInfo> buildAllDevicesByCompanyId(List<MetricSummary> data) {
         return data.stream()
-                .collect(Collectors.toMap(MetricSummary::getDeviceAlias,
-                        m -> DeviceConnectInfo.builder()
-                                .type(m.getType())
-                                .status(m.getStatus())
-                                .sid(m.getSid())
-                                .ip(m.getIp())
-                                .port(m.getPort())
-                                .statusValue(m.getStatusValue())
-                                .build())
-                );
+                .map(m -> DeviceConnectInfo.builder()
+                        .deviceAlias(m.getDeviceAlias())
+                        .type(m.getType())
+                        .status(m.getStatus())
+                        .sid(m.getSid())
+                        .ip(m.getIp())
+                        .port(m.getPort())
+                        .statusValue(m.getStatusValue())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringServiceImpl.java
@@ -3,9 +3,16 @@ package sandbox.semo.application.monitoring.service;
 import static sandbox.semo.application.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 
 import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -16,10 +23,15 @@ import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.device.repository.DeviceRepository;
 import sandbox.semo.domain.member.entity.Member;
 import sandbox.semo.domain.member.repository.MemberRepository;
+import sandbox.semo.domain.monitoring.dto.request.DeviceMonitoring;
+import sandbox.semo.domain.monitoring.dto.response.DetailPageData;
 import sandbox.semo.domain.monitoring.dto.response.DeviceConnectInfo;
 import sandbox.semo.domain.monitoring.dto.response.MetricSummary;
 import sandbox.semo.domain.monitoring.dto.response.SummaryPageData;
 import sandbox.semo.domain.monitoring.dto.response.TotalProcessInfo;
+import sandbox.semo.domain.monitoring.dto.response.TypeData;
+import sandbox.semo.domain.monitoring.entity.MonitoringMetric;
+import sandbox.semo.domain.monitoring.repository.MetricRepository;
 
 @Log4j2
 @Service
@@ -29,6 +41,7 @@ public class MonitoringServiceImpl implements MonitoringService {
 
     private final MemberRepository memberRepository;
     private final DeviceRepository deviceRepository;
+    private final MetricRepository metricRepository;
 
     @Override
     public SummaryPageData fetchSummaryData(Long memberId) {
@@ -137,6 +150,119 @@ public class MonitoringServiceImpl implements MonitoringService {
                                 .statusValue(m.getStatusValue())
                                 .build())
                 );
+    }
+
+    @Override
+    public DetailPageData fetchDetailData(DeviceMonitoring request, Long companyId) {
+        Duration interval = getDurationFromString(request.getInterval());
+        String deviceAlias = request.getDeviceAlias();
+        Long deviceId = deviceRepository.findIdByAliasAndCompanyId(deviceAlias, companyId);
+
+        List<MonitoringMetric> metrics = metricRepository.findMetricsByTimeRangeAndDeviceId(
+                request.getStartTime(),
+                request.getEndTime(),
+                deviceId
+        );
+
+        Function<MonitoringMetric, String> timeStampExtractor = metric -> {
+            LocalDateTime collectedAt = metric.getId().getCollectedAt();
+            long seconds = interval.getSeconds();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+            return collectedAt.truncatedTo(ChronoUnit.SECONDS)
+                    .minusSeconds(collectedAt.getSecond() % seconds)
+                    .format(formatter);
+        };
+
+        Map<String, Integer> totalSessions = mapMetricValue(metrics, timeStampExtractor,
+                MonitoringMetric::getTotalSessionCount);
+        Map<String, Integer> activeSessions = mapMetricValue(metrics, timeStampExtractor,
+                MonitoringMetric::getActiveSessionCount);
+        Map<String, Integer> blockingSessions = mapMetricValue(metrics, timeStampExtractor,
+                MonitoringMetric::getBlockingSessionCount);
+        Map<String, Integer> waitSessions = mapMetricValue(metrics, timeStampExtractor,
+                MonitoringMetric::getWaitSessionCount);
+
+        Map<String, List<TypeData>> sessionCountGroupByUser = mapMetricTypeData(
+                metrics,
+                timeStampExtractor,
+                MonitoringMetric::getSessionCountGroupByUser
+        );
+        Map<String, List<TypeData>> sessionCountGroupByCommand = mapMetricTypeData(
+                metrics,
+                timeStampExtractor,
+                MonitoringMetric::getSessionCountGroupByCommand
+        );
+        Map<String, List<TypeData>> sessionCountGroupByMachine = mapMetricTypeData(
+                metrics,
+                timeStampExtractor,
+                MonitoringMetric::getSessionCountGroupByMachine
+        );
+        Map<String, List<TypeData>> sessionCountGroupByType = mapMetricTypeData(
+                metrics,
+                timeStampExtractor,
+                MonitoringMetric::getSessionCountGroupByType
+        );
+
+        return DetailPageData.builder()
+                .deviceAlias(deviceAlias)
+                .totalSessions(totalSessions)
+                .activeSessions(activeSessions)
+                .blockingSessions(blockingSessions)
+                .waitSessions(waitSessions)
+                .sessionCountGroupByUser(sessionCountGroupByUser)
+                .sessionCountGroupByCommand(sessionCountGroupByCommand)
+                .sessionCountGroupByMachine(sessionCountGroupByMachine)
+                .sessionCountGroupByType(sessionCountGroupByType)
+                .build();
+    }
+
+    private Duration getDurationFromString(String interval) {
+        return switch (interval) {
+            case "10s" -> Duration.ofSeconds(10);
+            case "30s" -> Duration.ofSeconds(30);
+            case "1m" -> Duration.ofMinutes(1);
+            default -> Duration.ofSeconds(5);
+        };
+    }
+
+    private <T> Map<String, Integer> mapMetricValue(
+            List<MonitoringMetric> metrics,
+            Function<MonitoringMetric, String> timeStampExtractor,
+            Function<MonitoringMetric, T> valueExtractor) {
+
+        return metrics.stream()
+                .collect(Collectors.toMap(
+                        timeStampExtractor,
+                        metric -> (Integer) valueExtractor.apply(metric),
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new));
+    }
+
+    private Map<String, List<TypeData>> mapMetricTypeData(
+            List<MonitoringMetric> metrics,
+            Function<MonitoringMetric, String> timeStampExtractor,
+            Function<MonitoringMetric, String> dataExtractor) {
+
+        return metrics.stream()
+                .collect(Collectors.toMap(
+                        timeStampExtractor,
+                        metric -> parseToTypeDataList(dataExtractor.apply(metric)),
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new));
+    }
+
+    private List<TypeData> parseToTypeDataList(String data) {
+        if (data == null || data.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(data.split(","))
+                .map(entry -> entry.split(":"))
+                .map(parts -> TypeData.builder()
+                        .name(parts[0].trim())
+                        .value(Integer.parseInt(parts[1].trim()))
+                        .build())
+                .collect(Collectors.toList());
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/monitoring/service/MonitoringServiceImpl.java
@@ -107,7 +107,7 @@ public class MonitoringServiceImpl implements MonitoringService {
                         m -> m.getStatusValue().intValue(),
                         (oldValue, newValue) -> oldValue, LinkedHashMap::new));
 
-        Map<String, Integer> unUsedDevice = data.stream()
+        Map<String, Integer> unusedDevice = data.stream()
                 .filter(this::isInactive)
                 .filter(m -> m.getStatusValue() >= 4320L) // 3 days == 4320 min
                 .sorted((a, b) -> Long.compare(b.getStatusValue(), a.getStatusValue()))
@@ -122,7 +122,7 @@ public class MonitoringServiceImpl implements MonitoringService {
                 .blockedDeviceCnt(blockedDeviceCnt)
                 .topUsedDevices(topUsedDevices)
                 .warnDevice(warnDevice)
-                .unUsedDevice(unUsedDevice)
+                .unusedDevice(unusedDevice)
                 .build();
     }
 

--- a/semo-core/src/main/java/sandbox/semo/domain/device/repository/DeviceRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/device/repository/DeviceRepository.java
@@ -9,6 +9,15 @@ import sandbox.semo.domain.device.entity.Device;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
 
+    @Query("SELECT d.id " +
+            "FROM Device d " +
+            "WHERE d.deviceAlias = :deviceAlias " +
+            "AND d.company.id = :companyId")
+    Long findIdByAliasAndCompanyId(
+            @Param("deviceAlias") String deviceAlias,
+            @Param("companyId") Long companyId
+    );
+
     @Query("SELECT new sandbox.semo.domain.device.dto.response.DeviceInfo" +
             "(d.deviceAlias, d.type, d.ip, d.port, d.sid, d.status, d.updatedAt) " +
             "FROM Device d " +

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/request/DeviceMonitoring.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/request/DeviceMonitoring.java
@@ -1,0 +1,20 @@
+package sandbox.semo.domain.monitoring.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+public class DeviceMonitoring {
+
+    private String deviceAlias;
+
+    private String interval;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endTime;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/DetailPageData.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/DetailPageData.java
@@ -1,0 +1,22 @@
+package sandbox.semo.domain.monitoring.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DetailPageData {
+
+    private String deviceAlias;
+    private Map<String, Integer> totalSessions;
+    private Map<String, Integer> activeSessions;
+    private Map<String, Integer> blockingSessions;
+    private Map<String, Integer> waitSessions;
+    private Map<String, List<TypeData>> sessionCountGroupByUser;
+    private Map<String, List<TypeData>> sessionCountGroupByCommand;
+    private Map<String, List<TypeData>> sessionCountGroupByMachine;
+    private Map<String, List<TypeData>> sessionCountGroupByType;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/DeviceConnectInfo.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/DeviceConnectInfo.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DeviceConnectInfo {
 
+    private String deviceAlias;
     private String type;
     private String status;
     private String sid;

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/SummaryPageData.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/SummaryPageData.java
@@ -1,6 +1,6 @@
 package sandbox.semo.domain.monitoring.dto.response;
 
-import java.util.Map;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,7 +16,7 @@ public class SummaryPageData {
 
     private TotalProcessInfo totalProcessInfo;
 
-    private Map<String, DeviceConnectInfo> allDevices;
+    private List<DeviceConnectInfo> allDevices;
 
 }
 

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/TimeSeriesData.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/TimeSeriesData.java
@@ -1,0 +1,27 @@
+package sandbox.semo.domain.monitoring.dto.response;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TimeSeriesData {
+
+    private int totalSessions;
+
+    private int activeSessions;
+
+    private int blockingSessions;
+
+    private int waitingSessions;
+
+    private Map<String, Integer> sessionCountGroupByUser;
+
+    private Map<String, Integer> sessionCountGroupByCommand;
+
+    private Map<String, Integer> sessionCountGroupByMachine;
+
+    private Map<String, Integer> sessionCountGroupByType;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/TotalProcessInfo.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/TotalProcessInfo.java
@@ -22,6 +22,6 @@ public class TotalProcessInfo {
 
     private Map<String, Integer> warnDevice;
 
-    private Map<String, Integer> unUsedDevice;
+    private Map<String, Integer> unusedDevice;
 
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/TypeData.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/dto/response/TypeData.java
@@ -1,0 +1,17 @@
+package sandbox.semo.domain.monitoring.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TypeData {
+
+    private String name;
+    private int value;
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/repository/MetricRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/repository/MetricRepository.java
@@ -1,0 +1,23 @@
+package sandbox.semo.domain.monitoring.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sandbox.semo.domain.monitoring.entity.MonitoringMetric;
+
+public interface MetricRepository extends JpaRepository<MonitoringMetric, Long> {
+
+    @Query("SELECT m " +
+            "FROM MonitoringMetric m " +
+            "WHERE m.id.collectedAt BETWEEN :startTime AND :endTime " +
+            "AND m.device.id = :deviceId " +
+            "ORDER BY m.id.collectedAt")
+    List<MonitoringMetric> findMetricsByTimeRangeAndDeviceId(
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime,
+            @Param("deviceId") Long deviceId
+    );
+
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/monitoring/repository/SessionDataRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/monitoring/repository/SessionDataRepository.java
@@ -1,0 +1,7 @@
+package sandbox.semo.domain.monitoring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sandbox.semo.domain.monitoring.entity.SessionData;
+
+public interface SessionDataRepository extends JpaRepository<SessionData, Long> {
+}


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #40 

<br>

## 💡 Key Changes
- 클라이언트에서 로그인한 회사의 특정 장비의 정보를 특정 범위에 차트로 표시하기 위해 필요한 시계열 데이터를 리턴합니다.

**`API RequestBody` 예시**
```
{
  "deviceAlias": "LOCALHOST1",
  "interval": "5s",
  "startTime": "2024-11-03T17:27:00",
  "endTime": "2024-11-03T17:32:00"
}
```

**ORACLE SQL QUERY**
```sql
SELECT m
FROM MonitoringMetric m
WHERE m.id.collectedAt BETWEEN :startTime AND :endTime
AND m.device.id = :deviceId
ORDER BY m.id.collectedAt
```
- `MonitoringMetric`: 조회할 테이블.
- `:startTime` 및 `:endTime`: 조회할 시간 범위의 시작과 끝을 나타내는 바인딩 변수.
- `:deviceId`: 특정 기기의 ID를 필터링하기 위한 바인딩 변수.
- `ORDER BY m.id.collectedAt`: 수집된 시간 순으로 결과를 정렬.

> 차트 전체 시간 범위: `5min` - 클라이언트에서 범위를 지정 받아야 합니다.
> 차트 요소별 기준: `5sec` - 클라이언트에서 범위를 지정 받아야 합니다.(**default** - `5s` 아래의 메소드 참고)
```java
private Duration getDurationFromString(String interval) {
        return switch (interval) {
            case "10s" -> Duration.ofSeconds(10);
            case "30s" -> Duration.ofSeconds(30);
            case "1m" -> Duration.ofMinutes(1);
            default -> Duration.ofSeconds(5);
        };
    }
```
- 데이터의 예시는 이슈(`Comment`), 테스트 첨부이미지를 확인해주시길 바랍니다.

<br>

## ✅ Test - PostMan Tool 사용
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/ffcd0441-a0b8-49c9-a097-955ed2d55ce5">


<br>


## ➕ ETC 
- `startTime`, `endTime`을 클라이언트에서 받는 이유는 유연한 API 구현을 하기 위함입니다.
- `interval`의 경우 확장성을 고려해서 개발하였습니다. 현재 기준 GUI 설계에는 정확한 기준이 표시되어 있지는 않아서, 추후 **interval 및 차트 범위**가 변경될 수 있습니다.
