### PR TITLE
[Feat] Redis 적용하여 로그아웃 시 토큰 블랙리스트 관리 기능 구현

### DIFF
--- a/semo-api/build.gradle
+++ b/semo-api/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6' // JWT
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis' // Redis
 }
 
 tasks.bootJar {

--- a/semo-api/src/main/java/sandbox/semo/application/common/config/RedisConfig.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package sandbox.semo.application.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/semo-api/src/main/java/sandbox/semo/application/common/config/SecurityConfig.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/config/SecurityConfig.java
@@ -73,8 +73,8 @@ public class SecurityConfig {
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             ).logout(logout -> logout
-                .logoutUrl("/api/v1/logout")  // 로그아웃 URL 설정
-                .addLogoutHandler(jwtLogoutHandler)  // 커스텀 로그아웃 핸들러 추가
+                .logoutUrl("/api/v1/logout")
+                .addLogoutHandler(jwtLogoutHandler)
                 .logoutSuccessHandler(logoutSuccessHandler)
             );
         return http.build();

--- a/semo-api/src/main/java/sandbox/semo/application/common/config/SecurityConfig.java
+++ b/semo-api/src/main/java/sandbox/semo/application/common/config/SecurityConfig.java
@@ -19,10 +19,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 import sandbox.semo.application.security.authentication.JwtAuthenticationFilter;
+import sandbox.semo.application.security.authentication.JwtLogoutHandler;
+import sandbox.semo.application.security.authentication.JwtLogoutSuccessHandler;
 import sandbox.semo.application.security.authentication.LoginFilter;
 import sandbox.semo.application.security.authentication.MemberAuthProvider;
 import sandbox.semo.application.security.exception.MemberAuthExceptionEntryPoint;
 import sandbox.semo.application.security.util.JwtUtil;
+import sandbox.semo.application.security.util.RedisUtil;
 
 @Log4j2
 @Configuration
@@ -36,6 +39,9 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final MemberAuthExceptionEntryPoint authenticationEntryPoint;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final RedisUtil redisUtil;
+    private final JwtLogoutHandler jwtLogoutHandler;
+    private final JwtLogoutSuccessHandler logoutSuccessHandler;
 
     @Autowired
     public void configure(AuthenticationManagerBuilder auth) {
@@ -59,13 +65,17 @@ public class SecurityConfig {
             .exceptionHandling(exception -> exception
                 .authenticationEntryPoint(authenticationEntryPoint)
             )
-            .addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
+            .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, redisUtil),
                 LoginFilter.class)
             .addFilterAt(
                 new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil),
                 UsernamePasswordAuthenticationFilter.class)
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            ).logout(logout -> logout
+                .logoutUrl("/api/v1/logout")  // 로그아웃 URL 설정
+                .addLogoutHandler(jwtLogoutHandler)  // 커스텀 로그아웃 핸들러 추가
+                .logoutSuccessHandler(logoutSuccessHandler)
             );
         return http.build();
     }

--- a/semo-api/src/main/java/sandbox/semo/application/security/authentication/JwtAuthenticationFilter.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/authentication/JwtAuthenticationFilter.java
@@ -1,6 +1,11 @@
 package sandbox.semo.application.security.authentication;
 
 import static sandbox.semo.application.security.constant.SecurityConstants.API_LOGIN_PATH;
+import static sandbox.semo.application.security.exception.AuthErrorCode.BLACKLISTED_TOKEN;
+import static sandbox.semo.application.security.exception.AuthErrorCode.INVALID_AUTH_REQUEST;
+import static sandbox.semo.application.security.exception.AuthErrorCode.INVALID_TOKEN;
+import static sandbox.semo.application.security.exception.AuthErrorCode.TOKEN_EXPIRED;
+import static sandbox.semo.application.security.exception.AuthErrorCode.UNAUTHORIZED_USER;
 import static sandbox.semo.application.security.util.TokenExtractor.extractToken;
 
 import io.jsonwebtoken.Claims;
@@ -44,25 +49,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             if (redisUtil.isBlacklisted(token)) {
                 log.error(">>> [ ❌ 로그아웃된 토큰입니다 ]");
-                handleAuthenticationException(response, AuthErrorCode.BLACKLISTED_TOKEN);
+                handleAuthenticationException(response, BLACKLISTED_TOKEN);
                 return;
             }
             processAuthentication(token);
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             log.error(">>> [ ❌ 토큰이 만료되었습니다 ]");
-            handleAuthenticationException(response, AuthErrorCode.TOKEN_EXPIRED);
+            handleAuthenticationException(response, TOKEN_EXPIRED);
             return;
         } catch (BadCredentialsException e) {
             log.error(">>> [ ❌ 인증 실패: {} ]", e.getMessage());
-            handleAuthenticationException(response, AuthErrorCode.INVALID_AUTH_REQUEST);
+            handleAuthenticationException(response, INVALID_AUTH_REQUEST);
         } catch (JwtException e) {
             log.error(">>> [ ❌ 유효하지 않은 토큰입니다: {} ]", e.getMessage());
-            handleAuthenticationException(response, AuthErrorCode.INVALID_TOKEN);
+            handleAuthenticationException(response, INVALID_TOKEN);
             return;
         } catch (Exception e) {
             log.error(">>> [ ❌ 인증 처리 중 오류 발생: {} ]", e.getMessage());
-            handleAuthenticationException(response, AuthErrorCode.UNAUTHORIZED_USER);
+            handleAuthenticationException(response, UNAUTHORIZED_USER);
             return;
         }
     }

--- a/semo-api/src/main/java/sandbox/semo/application/security/authentication/JwtLogoutHandler.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/authentication/JwtLogoutHandler.java
@@ -1,0 +1,35 @@
+package sandbox.semo.application.security.authentication;
+
+import static sandbox.semo.application.security.util.TokenExtractor.extractToken;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import sandbox.semo.application.security.util.RedisUtil;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class JwtLogoutHandler implements LogoutHandler {
+
+    private final RedisUtil redisUtil;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) {
+
+        String authorization = request.getHeader("Authorization");
+        String token = extractToken(authorization);
+
+        try {
+            redisUtil.addToBlacklist(token);
+        } catch (Exception e) {
+            log.error(">>> [ ❌ 로그아웃 처리 중 오류: {} ]", e.getMessage());
+        }
+
+    }
+}

--- a/semo-api/src/main/java/sandbox/semo/application/security/authentication/JwtLogoutSuccessHandler.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/authentication/JwtLogoutSuccessHandler.java
@@ -1,0 +1,26 @@
+package sandbox.semo.application.security.authentication;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+import sandbox.semo.application.security.util.JsonResponseHelper;
+
+@Component
+public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("code", 200);
+        responseBody.put("message", "성공적으로 로그아웃 되었습니다.");
+
+        JsonResponseHelper.sendJsonSuccessResponse(response, responseBody);
+    }
+}

--- a/semo-api/src/main/java/sandbox/semo/application/security/authentication/LoginFilter.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/authentication/LoginFilter.java
@@ -3,7 +3,6 @@ package sandbox.semo.application.security.authentication;
 import static sandbox.semo.application.security.constant.SecurityConstants.ACCESS_CONTROL_EXPOSE_HEADERS;
 import static sandbox.semo.application.security.constant.SecurityConstants.API_LOGIN_PATH;
 import static sandbox.semo.application.security.constant.SecurityConstants.AUTHORIZATION_HEADER;
-import static sandbox.semo.application.security.constant.SecurityConstants.JWT_TOKEN_PREFIX;
 import static sandbox.semo.application.security.exception.AuthErrorCode.UNAUTHORIZED_USER;
 
 import jakarta.servlet.FilterChain;
@@ -67,7 +66,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String token = jwtUtil.generateToken(memberId, username, role, companyId);
 
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, AUTHORIZATION_HEADER);
-        response.addHeader(AUTHORIZATION_HEADER, JWT_TOKEN_PREFIX + token);
+        response.addHeader(AUTHORIZATION_HEADER, token);
 
         Map<String, Object> responseBody = new LinkedHashMap<>();
         responseBody.put("code", 200);

--- a/semo-api/src/main/java/sandbox/semo/application/security/exception/AuthErrorCode.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/exception/AuthErrorCode.java
@@ -18,7 +18,10 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_CREDENTIALS(BAD_REQUEST, "아이디 또는 비밀번호가 일치하지 않습니다."),
     UNAUTHORIZED_USER(UNAUTHORIZED, "인증 되지 않은 사용자 입니다. 다시 한번 확인해 주세요."),
     TOKEN_EXPIRED(UNAUTHORIZED, "인증이 만료되었습니다. 다시 로그인해 주세요."),
-    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 한번 확인해 주세요.");
+    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 한번 확인해 주세요."),
+    INVALID_AUTH_REQUEST(UNAUTHORIZED, "잘못된 인증 요청입니다."),
+    BLACKLISTED_TOKEN(UNAUTHORIZED, "이미 로그아웃된 토큰입니다.");
+
     private final HttpStatus httpStatus;
 
     private final String message;

--- a/semo-api/src/main/java/sandbox/semo/application/security/exception/MemberAuthExceptionEntryPoint.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/exception/MemberAuthExceptionEntryPoint.java
@@ -1,5 +1,7 @@
 package sandbox.semo.application.security.exception;
 
+import static sandbox.semo.application.security.exception.AuthErrorCode.UNAUTHORIZED_USER;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,10 +18,9 @@ public class MemberAuthExceptionEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-            AuthenticationException authException) throws IOException, ServletException {
+        AuthenticationException authException) throws IOException, ServletException {
         log.error(">>> [ ❌ 인증 실패: {} ]", authException.getMessage());
-        AuthErrorCode authErrorCode = AuthErrorCode.UNAUTHORIZED_USER;
-        JsonResponseHelper.sendJsonErrorResponse(response, authErrorCode);
+        JsonResponseHelper.sendJsonErrorResponse(response, UNAUTHORIZED_USER);
     }
 
 }

--- a/semo-api/src/main/java/sandbox/semo/application/security/util/RedisUtil.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/util/RedisUtil.java
@@ -1,0 +1,57 @@
+package sandbox.semo.application.security.util;
+
+import io.jsonwebtoken.Claims;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JwtUtil jwtUtil;
+
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
+    public void addToBlacklist(String token) {
+        try {
+            Claims claims = jwtUtil.validateAndGetClaimsFromToken(token);
+            long remainingTime = claims.getExpiration().getTime() - System.currentTimeMillis();
+
+            if (remainingTime > 0) {
+                String key = BLACKLIST_PREFIX + token;
+                redisTemplate.opsForValue().set(
+                    key,
+                    "logout",
+                    remainingTime,
+                    TimeUnit.MILLISECONDS
+                );
+                log.info(">>> [ ✅ 토큰 블랙리스트 추가 완료. 만료까지 남은 시간: {}ms ]", remainingTime);
+            } else {
+                log.info(">>> [ ℹ️ 이미 만료된 토큰입니다 ]");
+            }
+        } catch (RedisConnectionFailureException e) {
+            log.error(">>> [ ❌ Redis 연결 실패: {} ]", e.getMessage());
+            throw new RuntimeException("Redis 연결에 실패했습니다", e);
+        } catch (Exception e) {
+            log.error(">>> [ ❌ Redis 저장 실패: {} ]", e.getMessage());
+            throw new RuntimeException("Redis 저장 실패", e);
+        }
+    }
+
+    public boolean isBlacklisted(String token) {
+        try {
+            String key = BLACKLIST_PREFIX + token;
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        } catch (Exception e) {
+            log.error(">>> [ ❌ Redis 조회 실패: {} ]", e.getMessage());
+            return false;
+        }
+    }
+}
+

--- a/semo-api/src/main/java/sandbox/semo/application/security/util/TokenExtractor.java
+++ b/semo-api/src/main/java/sandbox/semo/application/security/util/TokenExtractor.java
@@ -1,0 +1,32 @@
+package sandbox.semo.application.security.util;
+
+import static sandbox.semo.application.security.constant.SecurityConstants.JWT_TOKEN_PREFIX;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.BadCredentialsException;
+
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TokenExtractor {
+    public static String extractToken(String authorization) {
+        if (authorization == null) {
+            log.error(">>> [ ❌ Authorization 헤더가 없습니다 ]");
+            throw new BadCredentialsException("잘못된 요청입니다");
+        }
+
+        if (!authorization.startsWith(JWT_TOKEN_PREFIX)) {
+            log.error(">>> [ ❌ 잘못된 토큰 형식입니다: Bearer 형식이 아님 ]");
+            throw new BadCredentialsException("잘못된 토큰 형식입니다");
+        }
+
+        String token = authorization.substring(JWT_TOKEN_PREFIX.length());
+        if (token.isBlank()) {
+            log.error(">>> [ ❌ 토큰이 비어있습니다 ]");
+            throw new BadCredentialsException("토큰이 비어있습니다");
+        }
+
+        return token;
+    }
+}

--- a/semo-api/src/main/resources/application.yml
+++ b/semo-api/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.OracleDialect
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 server:
   port: 8080
 


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close : #45 
<br>

## 💡 Key Changes

### 1️⃣ 로그아웃 핸들러 구현하여 로그아웃 처리를 진행하였습니다.
![image](https://github.com/user-attachments/assets/4b2304c3-de0d-47ae-8d1f-4abf5de324ed)
- 로그아웃 진행 시 해당 토큰은 블랙리스트로 redis에 등록됩니다. redis에 등록된 토큰은 해당 토큰이 expired되면 자동으로 같이 삭제됩니다.

### 2️⃣ JwtAuthenticationFilter에서 블랙리스트 검증 로직을 추가하였습니다.
![image](https://github.com/user-attachments/assets/3f299984-a669-4449-bc8d-6934d2848c6d)
- 로그아웃 처리된 토큰이 요청으로 넘어올 시 401 에러를 반환하도록 설정하였습니다.
<br>

## ➕ ETC 
> 현재 Redis 관련 설정이 localhost로 설정되어있는데, 추후 vm 혹은 aws를 사용가능하게되면 적용하여 secret.yml로 관리할 예정입니다. 현재 설정으로 테스트하시려면 Redis설치가 필요합니다!
- [Redis 설치](https://github.com/microsoftarchive/redis/releases) 옆의 링크에서 msi 다운후 설치해주시면됩니다!


