### PR TITLE
[Fix] 사용자 요청 폼(MemberForm), 회사 등록 요청 폼(CompanyForm) 조회 수정

### DIFF
--- a/semo-api/src/main/java/sandbox/semo/application/company/controller/CompanyController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/company/controller/CompanyController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.company.service.CompanyService;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
+import sandbox.semo.domain.common.dto.response.OffsetPage;
 import sandbox.semo.domain.company.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.company.dto.request.CompanyFormRegister;
 import sandbox.semo.domain.company.dto.response.CompanyFormInfo;
@@ -37,45 +38,28 @@ public class CompanyController {
     @PostMapping("/{id}")
     public ApiResponse<Long> companyRegister(@PathVariable(value = "id") Long formId) {
         Long data = companyService.companyRegister(formId);
-        return ApiResponse.successResponse(
-                OK,
-                "성공적으로 회사가 등록되었습니다.",
-                data
-        );
+        return ApiResponse.successResponse(OK, "성공적으로 회사가 등록되었습니다.", data);
     }
 
     @GetMapping
     public ApiResponse<List<Company>> companyList(@RequestParam(required = false) String keyword) {
         List<Company> data = companyService.searchCompanyByName(keyword);
-        return ApiResponse.successResponse(
-                OK,
-                "성공적으로 회사 목록을 조회하였습니다.",
-                data
-        );
+        return ApiResponse.successResponse(OK, "성공적으로 회사 목록을 조회하였습니다.", data);
     }
 
     @PostMapping("/form")
     public ApiResponse<Void> formRegister(
             @RequestBody @Valid CompanyFormRegister registerForm) {
         companyService.formRegister(registerForm);
-        return ApiResponse.successResponse(
-                OK,
-                "성공적으로 폼을 제출하였습니다.");
+        return ApiResponse.successResponse(OK, "성공적으로 폼을 제출하였습니다.");
     }
 
     @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/form")
-    public ApiResponse<Page<CompanyFormInfo>> registerList(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-
-        Page<CompanyFormInfo> companyFormLists = companyService.findAllForms(page, size);
-        return ApiResponse.successResponse(
-                OK,
-                "성공적으로 목록을 조회하였습니다.",
-                companyFormLists
-        );
-
+    public ApiResponse<OffsetPage<CompanyFormInfo>> getFormList(
+            @RequestParam(defaultValue = "1") int page) {
+        OffsetPage<CompanyFormInfo> data = companyService.findForms(page, 10);
+        return ApiResponse.successResponse(OK, "성공적으로 목록을 조회하였습니다.", data);
     }
 
     @PreAuthorize("hasRole('SUPER')")
@@ -83,11 +67,6 @@ public class CompanyController {
     public ApiResponse<FormDecisionResponse> formUpdate(
             @RequestBody @Valid CompanyFormDecision updateForm) {
         FormDecisionResponse data = companyService.updateStatus(updateForm);
-
-        return ApiResponse.successResponse(
-                OK,
-                "성공적으로 처리되었습니다.",
-                data
-        );
+        return ApiResponse.successResponse(OK, "성공적으로 처리되었습니다.", data);
     }
 }

--- a/semo-api/src/main/java/sandbox/semo/application/company/controller/CompanyController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/company/controller/CompanyController.java
@@ -6,7 +6,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;

--- a/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyService.java
@@ -1,7 +1,6 @@
 package sandbox.semo.application.company.service;
 
 import java.util.List;
-import org.springframework.data.domain.Page;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
 import sandbox.semo.domain.common.dto.response.OffsetPage;
 import sandbox.semo.domain.company.dto.request.CompanyFormDecision;

--- a/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyService.java
@@ -3,6 +3,7 @@ package sandbox.semo.application.company.service;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
+import sandbox.semo.domain.common.dto.response.OffsetPage;
 import sandbox.semo.domain.company.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.company.dto.request.CompanyFormRegister;
 import sandbox.semo.domain.company.dto.response.CompanyFormInfo;
@@ -16,7 +17,7 @@ public interface CompanyService {
 
     void formRegister(CompanyFormRegister request);
 
-    Page<CompanyFormInfo> findAllForms(int page, int size);
+    OffsetPage<CompanyFormInfo> findForms(int page, int size);
 
     FormDecisionResponse updateStatus(CompanyFormDecision request);
 }

--- a/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyServiceImpl.java
@@ -5,13 +5,8 @@ import static sandbox.semo.application.company.exception.CompanyErrorCode.COMPAN
 import static sandbox.semo.application.company.exception.CompanyErrorCode.FORM_DOES_NOT_EXIST;
 import static sandbox.semo.application.company.exception.CompanyErrorCode.STATUS_NOT_APPROVED;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sandbox.semo.application.common.exception.CommonBusinessException;
@@ -26,8 +21,6 @@ import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.company.entity.CompanyForm;
 import sandbox.semo.domain.company.repository.CompanyFormRepository;
 import sandbox.semo.domain.company.repository.CompanyRepository;
-import sandbox.semo.domain.member.dto.response.MemberFormInfo;
-import sandbox.semo.domain.member.entity.MemberForm;
 
 @Service
 @Transactional(readOnly = true)

--- a/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/company/service/CompanyServiceImpl.java
@@ -1,5 +1,6 @@
 package sandbox.semo.application.company.service;
 
+import static sandbox.semo.application.common.exception.CommonErrorCode.BAD_REQUEST;
 import static sandbox.semo.application.company.exception.CompanyErrorCode.COMPANY_ALREADY_EXISTS;
 import static sandbox.semo.application.company.exception.CompanyErrorCode.FORM_DOES_NOT_EXIST;
 import static sandbox.semo.application.company.exception.CompanyErrorCode.STATUS_NOT_APPROVED;
@@ -13,8 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sandbox.semo.application.common.exception.CommonBusinessException;
 import sandbox.semo.application.company.exception.CompanyBusinessException;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
+import sandbox.semo.domain.common.dto.response.OffsetPage;
 import sandbox.semo.domain.common.entity.FormStatus;
 import sandbox.semo.domain.company.dto.request.CompanyFormDecision;
 import sandbox.semo.domain.company.dto.request.CompanyFormRegister;
@@ -23,6 +26,8 @@ import sandbox.semo.domain.company.entity.Company;
 import sandbox.semo.domain.company.entity.CompanyForm;
 import sandbox.semo.domain.company.repository.CompanyFormRepository;
 import sandbox.semo.domain.company.repository.CompanyRepository;
+import sandbox.semo.domain.member.dto.response.MemberFormInfo;
+import sandbox.semo.domain.member.entity.MemberForm;
 
 @Service
 @Transactional(readOnly = true)
@@ -79,19 +84,25 @@ public class CompanyServiceImpl implements CompanyService {
         }
     }
 
-    /**
-     * TODO: 0번째 에지부터 data가 없으면, 빈배열
-     * totalPage를 넘어갔을 때 data가 없으면 예외처리 발생
-     **/
     @Override
-    public Page<CompanyFormInfo> findAllForms(int page, int size) {
-        List<Sort.Order> sorts = new ArrayList<>();
-        sorts.add(Sort.Order.desc("requestDate"));
+    public OffsetPage<CompanyFormInfo> findForms(int page, int size) {
+        if (page < 1) {
+            throw new CommonBusinessException(BAD_REQUEST);
+        }
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
-        Page<CompanyForm> companyFormPage = companyFormRepository.findAll(pageable);
+        int offset = (page - 1) * size;
+        List<CompanyForm> companyForms = companyFormRepository.findPageWithOffset(offset, size);
+        long totalCount = companyFormRepository.count();
+        List<CompanyFormInfo> content = companyForms.stream()
+                .map(this::mapToCompanyFormInfo)
+                .toList();
+        int pageCount = (int) Math.ceil((double) totalCount / size);
+        boolean hasNext = page < pageCount;
+        return new OffsetPage<>(pageCount, content, hasNext);
+    }
 
-        return companyFormPage.map(companyForm -> CompanyFormInfo.builder()
+    private CompanyFormInfo mapToCompanyFormInfo(CompanyForm companyForm) {
+        return CompanyFormInfo.builder()
                 .formId(companyForm.getId())
                 .companyName(companyForm.getCompanyName())
                 .ownerName(companyForm.getOwnerName())
@@ -100,7 +111,7 @@ public class CompanyServiceImpl implements CompanyService {
                 .formStatus(companyForm.getFormStatus())
                 .requestDate(companyForm.getRequestDate())
                 .approvedAt(companyForm.getApprovedAt())
-                .build());
+                .build();
     }
 
     @Transactional

--- a/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.member.service.MemberService;
 import sandbox.semo.application.security.authentication.JwtMemberDetails;
+import sandbox.semo.domain.common.dto.response.CursorPage;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
 import sandbox.semo.domain.member.dto.request.MemberFormDecision;
 import sandbox.semo.domain.member.dto.request.MemberFormRegister;
@@ -68,10 +68,9 @@ public class MemberController {
 
     @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/form")
-    public ApiResponse<Page<MemberFormInfo>> getFormList(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        Page<MemberFormInfo> data = memberService.findAllForms(page, size);
+    public ApiResponse<CursorPage<MemberFormInfo>> getFormList(
+            @RequestParam(required = false) Long cursor) {
+        CursorPage<MemberFormInfo> data = memberService.findForms(cursor, 10);
         return ApiResponse.successResponse(OK, "성공적으로 목록을 조회하였습니다.", data);
     }
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
@@ -69,8 +69,8 @@ public class MemberController {
     @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/form")
     public ApiResponse<CursorPage<MemberFormInfo>> getFormList(
-            @RequestParam(required = false) Long cursor) {
-        CursorPage<MemberFormInfo> data = memberService.findForms(cursor, 10);
+            @RequestParam(required = false) Long page) {
+        CursorPage<MemberFormInfo> data = memberService.findForms(page, 10);
         return ApiResponse.successResponse(OK, "성공적으로 목록을 조회하였습니다.", data);
     }
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/controller/MemberController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sandbox.semo.application.common.response.ApiResponse;
 import sandbox.semo.application.member.service.MemberService;
 import sandbox.semo.application.security.authentication.JwtMemberDetails;
-import sandbox.semo.domain.common.dto.response.CursorPage;
+import sandbox.semo.domain.common.dto.response.OffsetPage;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
 import sandbox.semo.domain.member.dto.request.MemberFormDecision;
 import sandbox.semo.domain.member.dto.request.MemberFormRegister;
@@ -68,9 +68,9 @@ public class MemberController {
 
     @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/form")
-    public ApiResponse<CursorPage<MemberFormInfo>> getFormList(
-            @RequestParam(required = false) Long page) {
-        CursorPage<MemberFormInfo> data = memberService.findForms(page, 10);
+    public ApiResponse<OffsetPage<MemberFormInfo>> getFormList(
+            @RequestParam(defaultValue = "1") int page) {
+        OffsetPage<MemberFormInfo> data = memberService.findForms(page, 10);
         return ApiResponse.successResponse(OK, "성공적으로 목록을 조회하였습니다.", data);
     }
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
@@ -2,6 +2,7 @@ package sandbox.semo.application.member.service;
 
 import java.util.List;
 import org.springframework.data.domain.Page;
+import sandbox.semo.domain.common.dto.response.CursorPage;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
 import sandbox.semo.domain.member.dto.request.MemberFormDecision;
 import sandbox.semo.domain.member.dto.request.MemberFormRegister;
@@ -22,7 +23,7 @@ public interface MemberService {
 
     void formRegister(MemberFormRegister request);
 
-    Page<MemberFormInfo> findAllForms(int page, int size);
+    CursorPage<MemberFormInfo> findForms(Long cursor, int size);
 
     FormDecisionResponse updateForm(MemberFormDecision request);
 
@@ -33,4 +34,5 @@ public interface MemberService {
     void deleteMember(MemberRemove request);
 
     List<MemberInfo> findAllMembers(Long ownCompanyId, Role ownRole, MemberSearchFilter request);
+
 }

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberService.java
@@ -1,8 +1,7 @@
 package sandbox.semo.application.member.service;
 
 import java.util.List;
-import org.springframework.data.domain.Page;
-import sandbox.semo.domain.common.dto.response.CursorPage;
+import sandbox.semo.domain.common.dto.response.OffsetPage;
 import sandbox.semo.domain.common.dto.response.FormDecisionResponse;
 import sandbox.semo.domain.member.dto.request.MemberFormDecision;
 import sandbox.semo.domain.member.dto.request.MemberFormRegister;
@@ -23,7 +22,7 @@ public interface MemberService {
 
     void formRegister(MemberFormRegister request);
 
-    CursorPage<MemberFormInfo> findForms(Long cursor, int size);
+    OffsetPage<MemberFormInfo> findForms(int page, int size);
 
     FormDecisionResponse updateForm(MemberFormDecision request);
 

--- a/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
+++ b/semo-api/src/main/java/sandbox/semo/application/member/service/MemberServiceImpl.java
@@ -142,9 +142,10 @@ public class MemberServiceImpl implements MemberService {
                 null :
                 content.get(content.size() - 1).getFormId();
         long totalCount = memberFormRepository.count();
+        long pageButton = (totalCount % size) + 1;
         boolean hasNext = nextCursor != null;
 
-        return new CursorPage<>(totalCount, content, hasNext, nextCursor);
+        return new CursorPage<>(pageButton, content, hasNext, nextCursor);
     }
 
     private MemberFormInfo mapToMemberFormInfo(MemberForm memberForm) {

--- a/semo-core/src/main/java/sandbox/semo/domain/common/dto/response/CursorPage.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/common/dto/response/CursorPage.java
@@ -1,0 +1,15 @@
+package sandbox.semo.domain.common.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CursorPage<T> {
+
+    private long totalCount;    // 총 데이터 개수
+    private List<T> content;    // 현재 페이지 데이터
+    private boolean hasNext;    // 다음 페이지 여부
+    private Long nextCursor;    // 다음 페이지 커서
+}

--- a/semo-core/src/main/java/sandbox/semo/domain/common/dto/response/CursorPage.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/common/dto/response/CursorPage.java
@@ -8,7 +8,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class CursorPage<T> {
 
-    private long totalCount;    // 총 데이터 개수
+    private long pageButton;
     private List<T> content;    // 현재 페이지 데이터
     private boolean hasNext;    // 다음 페이지 여부
     private Long nextCursor;    // 다음 페이지 커서

--- a/semo-core/src/main/java/sandbox/semo/domain/common/dto/response/OffsetPage.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/common/dto/response/OffsetPage.java
@@ -6,10 +6,10 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class CursorPage<T> {
+public class OffsetPage<T> {
 
-    private long pageButton;
+    private long pageCount;
     private List<T> content;    // 현재 페이지 데이터
     private boolean hasNext;    // 다음 페이지 여부
-    private Long nextCursor;    // 다음 페이지 커서
+
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/company/repository/CompanyFormRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/company/repository/CompanyFormRepository.java
@@ -1,13 +1,10 @@
 package sandbox.semo.domain.company.repository;
 
 import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sandbox.semo.domain.company.entity.CompanyForm;
-import sandbox.semo.domain.member.entity.MemberForm;
 
 public interface CompanyFormRepository extends JpaRepository<CompanyForm, Long> {
 

--- a/semo-core/src/main/java/sandbox/semo/domain/company/repository/CompanyFormRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/company/repository/CompanyFormRepository.java
@@ -1,12 +1,21 @@
 package sandbox.semo.domain.company.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sandbox.semo.domain.company.entity.CompanyForm;
+import sandbox.semo.domain.member.entity.MemberForm;
 
 public interface CompanyFormRepository extends JpaRepository<CompanyForm, Long> {
 
-    Page<CompanyForm> findAll(Pageable pageable);
+    @Query(value = """
+            SELECT * FROM COMPANY_FORM
+            ORDER BY REQUEST_DATE DESC
+            OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY
+            """, nativeQuery = true)
+    List<CompanyForm> findPageWithOffset(@Param("offset") int offset, @Param("size") int size);
 
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberFormRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberFormRepository.java
@@ -1,8 +1,26 @@
 package sandbox.semo.domain.member.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sandbox.semo.domain.member.entity.MemberForm;
 
 public interface MemberFormRepository extends JpaRepository<MemberForm, Long> {
+
+    @Query(value = """
+            SELECT * FROM MEMBER_FORM 
+            ORDER BY FORM_ID DESC 
+            FETCH FIRST :size ROWS ONLY
+            """, nativeQuery = true)
+    List<MemberForm> findFirstPage(@Param("size") int size);
+
+    @Query(value = """
+            SELECT * FROM MEMBER_FORM 
+            WHERE FORM_ID < :cursor 
+            ORDER BY FORM_ID DESC 
+            FETCH FIRST :size ROWS ONLY
+            """, nativeQuery = true)
+    List<MemberForm> findNextPage(@Param("cursor") Long cursor, @Param("size") int size);
 
 }

--- a/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberFormRepository.java
+++ b/semo-core/src/main/java/sandbox/semo/domain/member/repository/MemberFormRepository.java
@@ -9,18 +9,10 @@ import sandbox.semo.domain.member.entity.MemberForm;
 public interface MemberFormRepository extends JpaRepository<MemberForm, Long> {
 
     @Query(value = """
-            SELECT * FROM MEMBER_FORM 
-            ORDER BY FORM_ID DESC 
-            FETCH FIRST :size ROWS ONLY
+            SELECT * FROM MEMBER_FORM
+            ORDER BY REQUEST_DATE DESC
+            OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY
             """, nativeQuery = true)
-    List<MemberForm> findFirstPage(@Param("size") int size);
-
-    @Query(value = """
-            SELECT * FROM MEMBER_FORM 
-            WHERE FORM_ID < :cursor 
-            ORDER BY FORM_ID DESC 
-            FETCH FIRST :size ROWS ONLY
-            """, nativeQuery = true)
-    List<MemberForm> findNextPage(@Param("cursor") Long cursor, @Param("size") int size);
+    List<MemberForm> findPageWithOffset(@Param("offset") int offset, @Param("size") int size);
 
 }


### PR DESCRIPTION
## #️⃣ Relationship Issues
- #61 

<br>

## 💡 Key Changes
### 🚀 사용자 등록 요청 폼, 회사 등록 요청 폼 조회 API 수정
**[Offset 기반 페이지네이션]**
- 버튼식 페이지네이션에는 Offset 기반의 페이지네이션 처리 방식을 적용하였습니다.
- 응답값은 아래와 같습니다.
> `data.pageCount`: 필요 버튼 개수
> `data.content`: 조회 내용
> `data.hasNext`: 다음 페이지가 있다는 내용을 true, false로 나타냄. 클라이언트에서는 이를 활용해서 ">" 다음 페이지 아이콘에 활용 가능할 것 같아서 추가함 

## ✅ Test - PostMan Tool 사용
<img width="1448" alt="image" src="https://github.com/user-attachments/assets/2e17404f-2995-4f33-8e01-d55b11baaa69">

```json
{
    "code": 200,
    "message": "성공적으로 목록을 조회하였습니다.",
    "data": {
        "pageCount": 2,
        "content": [
            {
                "formId": 63,
                "company": {
                    "id": 9999,
                    "companyName": "(주)네모",
                    "taxId": "000-00-00001"
                },
                "ownerName": "김태연",
                "email": "garong1997@ewhain.net",
                "formStatus": "APPROVED",
                "requestDate": "2024-11-14 23:24:54",
                "approvedAt": "2024-11-15 15:19:01"
            },

            ( ... 생략 )

            {
                "formId": 2,
                "company": {
                    "id": 9999,
                    "companyName": "(주)네모",
                    "taxId": "000-00-00001"
                },
                "ownerName": "정답",
                "email": "nemo321@gmail.com",
                "formStatus": "DENIED",
                "requestDate": "2024-11-09 23:32:42",
                "approvedAt": null
            }
        ],
        "hasNext": true
    }
}
```

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/e2c644bd-bbb3-4109-9b95-fa8f12694d7e">
